### PR TITLE
Reset All Empire Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Features
 
-A Model-View-ViewModel (MVVM) like approach to state management. Less boiler plate and significantly reduced clutter in your Widget build functions than other state management solutions.
+Less boiler plate and significantly reduced clutter in your Widget build functions than other state management solutions.
 
 ## Getting Started
 

--- a/lib/src/empire_view_model.dart
+++ b/lib/src/empire_view_model.dart
@@ -203,6 +203,18 @@ abstract class EmpireViewModel {
     }
   }
 
+  ///Resets the value of all properties defined in the [empireProps] list
+  ///to their original value.
+  ///
+  void resetAll() {
+    final resetActions = <Map<EmpireProperty, dynamic>>[];
+    for (final prop in empireProps) {
+      resetActions.add({prop: prop.originalValue});
+    }
+
+    setMultiple(resetActions);
+  }
+
   ///Closes the state and error streams and removes any listeners associated with those streams
   @mustCallSuper
   void dispose() {

--- a/test/empire_property_tests/empire_property_test.dart
+++ b/test/empire_property_tests/empire_property_test.dart
@@ -55,6 +55,25 @@ void main() {
     testWidget = _MyWidget(viewModel: viewModel);
   });
 
+  group('Property Creation Tests', () {
+    test('createNullProperty - Value is Null', () {
+      final age = EmpireProperty<int?>(null);
+      expect(age.value, isNull);
+    });
+
+    test('createProperty - passed value equals property value', () {
+      const expectedValue = 10;
+      final age = EmpireProperty<int>(expectedValue);
+      expect(age.value, equals(expectedValue));
+    });
+
+    test('createProperty - set optional property name', () {
+      const expectedValue = 'age';
+      final age = EmpireProperty<int>(10, propertyName: expectedValue);
+      expect(age.propertyName, equals(expectedValue));
+    });
+  });
+
   group('EmpireProperty Equality Tests', () {
     test('equals - other is same value - are equal', () {
       final ageOne = EmpireProperty<int>(10);

--- a/test/empire_view_model_test.dart
+++ b/test/empire_view_model_test.dart
@@ -1,23 +1,38 @@
 import 'package:empire/empire.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+class _TestViewModel extends EmpireViewModel {
+  final name = EmpireStringProperty('Bob');
+  final age = EmpireIntProperty(20);
+
+  @override
+  Iterable<EmpireProperty> get empireProps => [name, age];
+}
+
 void main() {
-  group('Property Creation Tests', () {
-    test('createNullProperty - Value is Null', () {
-      final age = EmpireProperty<int?>(null);
-      expect(age.value, isNull);
-    });
+  late _TestViewModel viewModel;
 
-    test('createProperty - passed value equals property value', () {
-      const expectedValue = 10;
-      final age = EmpireProperty<int>(expectedValue);
-      expect(age.value, equals(expectedValue));
-    });
+  setUp(() {
+    viewModel = _TestViewModel();
+  });
 
-    test('createProperty - set optional property name', () {
-      const expectedValue = 'age';
-      final age = EmpireProperty<int>(10, propertyName: expectedValue);
-      expect(age.propertyName, equals(expectedValue));
-    });
+  test(
+      'resetAll - change property values - All values equal their original value',
+      () {
+    const changedName = 'Steve';
+    const changedAge = 100;
+    final originalName = viewModel.name.value;
+    final originalAge = viewModel.age.value;
+
+    viewModel.name(changedName);
+    viewModel.age(changedAge);
+
+    expect(viewModel.name.value, equals(changedName));
+    expect(viewModel.age.value, equals(changedAge));
+
+    viewModel.resetAll();
+
+    expect(viewModel.name.value, equals(originalName));
+    expect(viewModel.age.value, equals(originalAge));
   });
 }


### PR DESCRIPTION
resolves #72 

- Added function, `resetAll`, to EmpireViewModel. Calling this will reset all the tracked EmpireProperties for the view model to their original values and update the UI
- Removed the mention of MVVM from the README. We have diverged from a true MVVM pattern, so decided to remove the mention of it from the README.