### PR TITLE
Optional Value Constructor Argument on Nullable Properties

### DIFF
--- a/lib/src/empire_date_time_property.dart
+++ b/lib/src/empire_date_time_property.dart
@@ -362,7 +362,8 @@ class EmpireDateTimeProperty extends EmpireProperty<DateTime> {
 ///When the value of this changes, it will send a [EmpireStateChanged] event by default. This includes
 ///automatically triggering a UI rebuild.
 class EmpireNullableDateTimeProperty extends EmpireProperty<DateTime?> {
-  EmpireNullableDateTimeProperty(super.value, {super.propertyName});
+  EmpireNullableDateTimeProperty({DateTime? value, super.propertyName})
+      : super(value);
 
   ///Factory constructor for initializing an [EmpireNullableDateTimeProperty] to the current Date/Time.
   ///
@@ -375,7 +376,7 @@ class EmpireNullableDateTimeProperty extends EmpireProperty<DateTime?> {
   ///```
   factory EmpireNullableDateTimeProperty.now({String? propertyName}) {
     return EmpireNullableDateTimeProperty(
-      DateTime.now(),
+      value: DateTime.now(),
       propertyName: propertyName,
     );
   }
@@ -447,7 +448,10 @@ class EmpireNullableDateTimeProperty extends EmpireProperty<DateTime?> {
       {String? propertyName}) {
     final dateTime = DateTime.parse(formattedString);
 
-    return EmpireNullableDateTimeProperty(dateTime, propertyName: propertyName);
+    return EmpireNullableDateTimeProperty(
+      value: dateTime,
+      propertyName: propertyName,
+    );
   }
 
   // Constructs a new [EmpireNullableDateTimeProperty] instance based on [formattedString].
@@ -457,7 +461,10 @@ class EmpireNullableDateTimeProperty extends EmpireProperty<DateTime?> {
   static EmpireNullableDateTimeProperty tryParse(String formattedString,
       {String? propertyName}) {
     final dateTime = DateTime.tryParse(formattedString);
-    return EmpireNullableDateTimeProperty(dateTime, propertyName: propertyName);
+    return EmpireNullableDateTimeProperty(
+      value: dateTime,
+      propertyName: propertyName,
+    );
   }
 
   ///Sets the value to null

--- a/lib/src/empire_int_property.dart
+++ b/lib/src/empire_int_property.dart
@@ -114,7 +114,7 @@ class EmpireIntProperty extends EmpireProperty<int> {
 ///```
 ///
 class EmpireNullableIntProperty extends EmpireProperty<int?> {
-  EmpireNullableIntProperty(super.value, {super.propertyName});
+  EmpireNullableIntProperty({int? value, super.propertyName}) : super(value);
 
   ///Factory constructor for initializing an [EmpireNullableIntProperty] to zero.
   ///
@@ -126,7 +126,7 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
   ///final numberOfFriends = EmpireNullableIntProperty.zero();
   ///```
   factory EmpireNullableIntProperty.zero({String? propertyName}) {
-    return EmpireNullableIntProperty(0, propertyName: propertyName);
+    return EmpireNullableIntProperty(value: 0, propertyName: propertyName);
   }
 
   /// Returns true if the int value is odd

--- a/lib/src/empire_property.dart
+++ b/lib/src/empire_property.dart
@@ -48,7 +48,7 @@ abstract class EmpireValue<T> {
 /////update the property value to five.
 ///age(5);
 ///```
-class EmpireProperty<T> implements EmpireValue<T?> {
+class EmpireProperty<T> implements EmpireValue<T> {
   String? propertyName;
 
   late T _originalValue;

--- a/lib/src/empire_property.dart
+++ b/lib/src/empire_property.dart
@@ -48,7 +48,7 @@ abstract class EmpireValue<T> {
 /////update the property value to five.
 ///age(5);
 ///```
-class EmpireProperty<T> implements EmpireValue<T> {
+class EmpireProperty<T> implements EmpireValue<T?> {
   String? propertyName;
 
   late T _originalValue;

--- a/test/empire_property_tests/date_time_property_test.dart
+++ b/test/empire_property_tests/date_time_property_test.dart
@@ -150,4 +150,17 @@ void main() {
       expect(property.compareTo(dt1), equals(expected));
     });
   });
+
+  group('EmpireNullableDateTimeProperty Tests', () {
+    test('Create New - No Constructor Arguments - Value is NULL', () {
+      final property = EmpireNullableDateTimeProperty();
+      expect(property.value, isNull);
+    });
+
+    test('Create New - value set - value equals constructure argument', () {
+      final expected = DateTime(2022, 1, 1);
+      final property = EmpireNullableDateTimeProperty(value: expected);
+      expect(property.value, equals(expected));
+    });
+  });
 }

--- a/test/empire_property_tests/int_property_test.dart
+++ b/test/empire_property_tests/int_property_test.dart
@@ -45,7 +45,7 @@ class _IntTestWidgetState extends EmpireState<IntTestWidget, IntViewModel> {
 }
 
 class NullableIntViewModel extends EmpireViewModel {
-  final age = EmpireNullableIntProperty(10);
+  final age = EmpireNullableIntProperty(value: 10);
 
   @override
   Iterable<EmpireProperty> get empireProps => [age];


### PR DESCRIPTION
resolves #79 

- Updated `EmpireNullableDateTimeProperty` and `EmpireNullableIntProperty` constructors so the value argument is optional instead of a required positional argument. 
- Added unit tests for `EmpireNullableDateTimeProperty` construction.