### PR TITLE
List property improvements

### DIFF
--- a/lib/src/empire_double_property.dart
+++ b/lib/src/empire_double_property.dart
@@ -15,9 +15,7 @@ part of 'empire_property.dart';
 ///Example
 ///```dart
 ///
-///late final EmpireDoubleProperty percentage;
-///
-///percentage = createDoubleProperty(10.0);
+///final percentage = EmpireDoubleProperty(10.0);
 ///
 ///print('${percentage + 5.2}'); //prints 15.2
 ///```
@@ -51,11 +49,14 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
   /// Throws an [UnsupportedError] if this number is not finite
   /// (NaN or an infinity).
   /// ```dart
-  /// print(3.0.round()); // 3
-  /// print(3.25.round()); // 3
-  /// print(3.5.round()); // 4
-  /// print(3.75.round()); // 4
-  /// print((-3.5).round()); // -4
+  /// final number = EmpireDoubleProperty(3.25);
+  /// print(number.roundToDouble()); // 3
+  ///
+  /// number(3.5);
+  /// print(number.roundToDouble()); // 4
+  ///
+  /// number(3.75);
+  /// print(number.roundToDouble()); // 4
   /// ```
   int round() => _value.round();
 
@@ -72,11 +73,14 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
   /// This means that for a value `d` in the range `-0.5 < d < 0.0`,
   /// the result is `-0.0`.
   /// ```dart
-  /// print(3.0.roundToDouble()); // 3.0
-  /// print(3.25.roundToDouble()); // 3.0
-  /// print(3.5.roundToDouble()); // 4.0
-  /// print(3.75.roundToDouble()); // 4.0
-  /// print((-3.5).roundToDouble()); // -4.0
+  /// final number = EmpireDoubleProperty(3.25);
+  /// print(number.roundToDouble()); // 3.0
+  ///
+  /// number(3.5);
+  /// print(number.roundToDouble()); // 4.0
+  ///
+  /// number(3.75);
+  /// print(number.roundToDouble()); // 4.0
   /// ```
   double roundToDouble() => _value.roundToDouble();
 
@@ -108,9 +112,7 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
 ///
 ///Example
 ///```dart
-///late final EmpireNullableDoubleProperty percentage;
-///
-///percentage = createNullableDoubleProperty();
+///final percentage = EmpireNullableDoubleProperty(10.0);
 ///
 ///if (percentage.isNull)
 ///{
@@ -121,9 +123,7 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
 ///Other Usages Examples
 ///```dart
 ///
-///late final EmpireNullableDoubleProperty percentage;
-///
-///percentage = createNullableDoubleProperty();
+///final percentage = EmpireNullableDoubleProperty();
 ///
 ///print('${percentage + 5.2}'); //throws EmpireNullValueException because no value has been set yet.
 ///
@@ -161,11 +161,14 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
   /// Throws an [UnsupportedError] if this number is not finite
   /// (NaN or an infinity).
   /// ```dart
-  /// print(3.0.round()); // 3
-  /// print(3.25.round()); // 3
-  /// print(3.5.round()); // 4
-  /// print(3.75.round()); // 4
-  /// print((-3.5).round()); // -4
+  /// final number = EmpireDoubleProperty(3.25);
+  /// print(number.roundToDouble()); // 3
+  ///
+  /// number(3.5);
+  /// print(number.roundToDouble()); // 4
+  ///
+  /// number(3.75);
+  /// print(number.roundToDouble()); // 4
   /// ```
   int? round() => _value?.round();
 
@@ -184,11 +187,14 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
   /// This means that for a value `d` in the range `-0.5 < d < 0.0`,
   /// the result is `-0.0`.
   /// ```dart
-  /// print(3.0.roundToDouble()); // 3.0
-  /// print(3.25.roundToDouble()); // 3.0
-  /// print(3.5.roundToDouble()); // 4.0
-  /// print(3.75.roundToDouble()); // 4.0
-  /// print((-3.5).roundToDouble()); // -4.0
+  /// final number = EmpireDoubleProperty(3.25);
+  /// print(number.roundToDouble()); // 3.0
+  ///
+  /// number(3.5);
+  /// print(number.roundToDouble()); // 4.0
+  ///
+  /// number(3.75);
+  /// print(number.roundToDouble()); // 4.0
   /// ```
   double? roundToDouble() => _value?.roundToDouble();
 

--- a/lib/src/empire_double_property.dart
+++ b/lib/src/empire_double_property.dart
@@ -162,13 +162,13 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
   /// (NaN or an infinity).
   /// ```dart
   /// final number = EmpireDoubleProperty(3.25);
-  /// print(number.roundToDouble()); // 3
+  /// print(number.round()); // 3
   ///
   /// number(3.5);
-  /// print(number.roundToDouble()); // 4
+  /// print(number.round()); // 4
   ///
   /// number(3.75);
-  /// print(number.roundToDouble()); // 4
+  /// print(number.round()); // 4
   /// ```
   int? round() => _value?.round();
 

--- a/lib/src/empire_double_property.dart
+++ b/lib/src/empire_double_property.dart
@@ -50,13 +50,13 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
   /// (NaN or an infinity).
   /// ```dart
   /// final number = EmpireDoubleProperty(3.25);
-  /// print(number.roundToDouble()); // 3
+  /// print(number.round()); // 3
   ///
   /// number(3.5);
-  /// print(number.roundToDouble()); // 4
+  /// print(number.round()); // 4
   ///
   /// number(3.75);
-  /// print(number.roundToDouble()); // 4
+  /// print(number.round()); // 4
   /// ```
   int round() => _value.round();
 

--- a/lib/src/empire_int_property.dart
+++ b/lib/src/empire_int_property.dart
@@ -15,9 +15,7 @@ part of 'empire_property.dart';
 ///Example
 ///```dart
 ///
-///late final EmpireIntProperty age;
-///
-///age = createIntProperty(10);
+//final age = EmpireIntProperty(10);
 ///
 ///print('${age + 5}'); //prints 15
 ///```
@@ -88,9 +86,7 @@ class EmpireIntProperty extends EmpireProperty<int> {
 ///
 ///Example
 ///```dart
-///late final EmpireNullableIntProperty age;
-///
-///age = createNullableIntProperty();
+///final age = EmpireNullableIntProperty();
 ///
 ///if (age.isNull)
 ///{
@@ -101,9 +97,7 @@ class EmpireIntProperty extends EmpireProperty<int> {
 ///Other Usages Examples
 ///```dart
 ///
-///late final EmpireNullableIntProperty age;
-///
-///age = createNullableIntProperty();
+///final age = EmpireNullableIntProperty();
 ///
 ///print('${age + 5}'); //throws EmpireNullValueException because no value has been set yet.
 ///

--- a/lib/src/empire_list_property.dart
+++ b/lib/src/empire_list_property.dart
@@ -279,7 +279,7 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   /// For example, [elementAt] may call `toElement` only once.
   ///
   /// Example:
-  /// ```dart import:convert
+  /// ```dart
   /// var products = EmpireListProperty(
   /// [
   ///   {"name": "Screwdriver", "price": 42.00},

--- a/lib/src/empire_list_property.dart
+++ b/lib/src/empire_list_property.dart
@@ -22,11 +22,38 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
     return EmpireListProperty(<T>[], propertyName: propertyName);
   }
 
+  /// Returns the first element.
+  ///
+  /// Throws a [StateError] if `this` is empty.
+  /// Otherwise returns the first element in the iteration order,
+  /// equivalent to `this.elementAt(0)`.
+  T get first => _value.first;
+
+  /// Returns the last element.
+  ///
+  /// Throws a [StateError] if `this` is empty.
+  /// Otherwise may iterate through the elements and returns the last one
+  /// seen.
+  T get last => _value.last;
+
+  /// Checks that this has only one element, and returns that element.
+  ///
+  /// Throws a [StateError] if `this` is empty or has more than one element.
+  T get single => _value.single;
+
+  /// A [List] of the objects in this list in reverse order.
+  /// ```dart
+  /// final numbers = EmpireListProperty['two', 'three', 'four'];
+  /// final reverseOrder = numbers.reversed;
+  /// print(reverseOrder.toList()); // [four, three, two]
+  /// ```
+  List<T> get reversed => _value.reversed.toList();
+
   /// The number of objects in this list.
   ///
   /// The valid indices for a list are `0` through `length - 1`.
   /// ```dart
-  /// final numbers = <int>[1, 2, 3];
+  /// final numbers = EmpireListProperty<int>[1, 2, 3];
   /// print(numbers.length); // 3
   /// ```
   int get length => _value.length;
@@ -35,7 +62,7 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   ///
   /// Example:
   /// ```dart
-  /// final emptyList = createEmptyListProperty<String>()
+  /// final emptyList = EmpireListProperty<String>([])
   /// print(emptyList.isEmpty); // true;
   /// ```
   bool get isEmpty => _value.isEmpty;
@@ -44,10 +71,68 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   ///
   /// Example:
   /// ```dart
-  /// final list = createListProperty<String>(['Bob'])
+  /// final list = EmpireListProperty<String>(['Bob'])
   /// print(list.isNotEmpty); // true;
   /// ```
   bool get isNotEmpty => _value.isNotEmpty;
+
+  /// Returns a new [List] with all elements that satisfy the
+  /// predicate [test].
+  ///
+  /// Example:
+  /// ```dart
+  /// final numbers = EmpireListProperty[1, 2, 3, 5, 6, 7];
+  /// var result = numbers.where((x) => x < 5); // (1, 2, 3)
+  /// result = numbers.where((x) => x > 5); // (6, 7)
+  /// result = numbers.where((x) => x.isEven); // (2, 6)
+  /// ```
+  List<T> where(bool Function(T element) test) {
+    return _value.where(test).toList();
+  }
+
+  /// Returns the first element that satisfies the given predicate [test].
+  ///
+  /// Iterates through elements and returns the first to satisfy [test].
+  ///
+  /// Example:
+  /// ```dart
+  /// final numbers = EmpireListProperty[1, 2, 3, 5, 6, 7];
+  /// var result = numbers.firstWhere((element) => element < 5); // 1
+  /// result = numbers.firstWhere((element) => element > 5); // 6
+  /// result =
+  ///     numbers.firstWhere((element) => element > 10, orElse: () => -1); // -1
+  /// ```
+  ///
+  /// If no element satisfies [test], the result of invoking the [orElse]
+  /// function is returned.
+  /// If [orElse] is omitted, it defaults to throwing a [StateError].
+  T firstWhere(bool Function(T element) test, {T Function()? orElse}) {
+    return value.firstWhere(test, orElse: orElse);
+  }
+
+  /// Returns the first element that satisfies the given predicate [test].
+  ///
+  /// Iterates through elements and returns the first to satisfy [test].
+  ///
+  /// Example:
+  /// ```dart
+  /// final numbers = EmpireListProperty[1, 2, 3, 5, 6, 7];
+  /// var result = numbers.firstWhere((element) => element < 5); // 1
+  /// result = numbers.firstWhere((element) => element > 5); // 6
+  /// result =
+  ///     numbers.firstWhere((element) => element > 10, orElse: () => -1); // -1
+  /// ```
+  ///
+  /// If no element satisfies [test], null is returned
+  T? firstWhereOrNull(bool Function(T element) test) {
+    final results = value.where(test);
+
+    if (results.isEmpty) {
+      return null;
+    } else {
+      return results.first;
+    }
+  }
 
   /// Adds [value] to the end of this list,
   /// extending the length by one.
@@ -55,7 +140,7 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   /// The list must be growable.
   ///
   /// ```dart
-  /// final numbers = <int>[1, 2, 3];
+  /// final numbers = EmpireListProperty<int>[1, 2, 3];
   /// numbers.add(4);
   /// print(numbers); // [1, 2, 3, 4]
   /// ```
@@ -73,7 +158,7 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   /// The list must be growable.
   ///
   /// ```dart
-  /// final numbers = <int>[1, 2, 3];
+  /// final numbers = EmpireListProperty<int>[1, 2, 3];
   /// numbers.addAll([4, 5, 6]);
   /// print(numbers); // [1, 2, 3, 4, 5, 6]
   /// ```
@@ -91,13 +176,13 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   /// The list must be growable.
   ///
   /// ```dart
-  /// final parts = <String>['head', 'shoulders', 'knees', 'toes'];
+  /// final parts = EmpireListProperty<String>['head', 'shoulders', 'knees', 'toes'];
   /// final retVal = parts.remove('head'); // true
   /// print(parts); // [shoulders, knees, toes]
   /// ```
   /// The method has no effect if [value] was not in the list.
   /// ```dart
-  /// final parts = <String>['shoulders', 'knees', 'toes'];
+  /// final parts = EmpireListProperty<String>['shoulders', 'knees', 'toes'];
   /// // Note: 'head' has already been removed.
   /// final retVal = parts.remove('head'); // false
   /// print(parts); // [shoulders, knees, toes]
@@ -122,7 +207,7 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   /// The [index] must be in the range `0 ≤ index < length`.
   /// The list must be growable.
   /// ```dart
-  /// final parts = <String>['head', 'shoulder', 'knees', 'toes'];
+  /// final parts = EmpireListProperty<String>['head', 'shoulder', 'knees', 'toes'];
   /// final retVal = parts.removeAt(2); // knees
   /// print(parts); // [head, shoulder, toes]
   /// ```
@@ -142,7 +227,7 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   /// The list must be growable.
   ///
   /// ```dart
-  /// final numbers = <int>[1, 2, 3];
+  /// final numbers = EmpireListProperty<int>[1, 2, 3];
   /// numbers.clear();
   /// print(numbers.length); // 0
   /// print(numbers); // []
@@ -166,19 +251,12 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   /// The equality used to determine whether [value] is equal to an element of
   /// the iterable defaults to the [Object.==] of the element.
   ///
-  /// Some types of iterable may have a different equality used for its elements.
-  /// For example, a [Set] may have a custom equality
-  /// (see [Set.identity]) that its `contains` uses.
-  /// Likewise the `Iterable` returned by a [Map.keys] call
-  /// should use the same equality that the `Map` uses for keys.
   ///
   /// Example:
   /// ```dart
-  /// final gasPlanets = <int, String>{1: 'Jupiter', 2: 'Saturn'};
-  /// final containsOne = gasPlanets.keys.contains(1); // true
-  /// final containsFive = gasPlanets.keys.contains(5); // false
-  /// final containsJupiter = gasPlanets.values.contains('Jupiter'); // true
-  /// final containsMercury = gasPlanets.values.contains('Mercury'); // false
+  /// final gasPlanets = EmpireListProperty<String>(['Jupiter', 'Saturn']);
+  /// final containsEarth = gasPlanets.contains('Earth'); // false
+  /// final containsJupiter = gasPlanets.contains('Jupiter'); // true
   /// ```
   bool contains(T value) => _value.contains(value);
 
@@ -200,22 +278,13 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   /// on any element where the result isn't needed.
   /// For example, [elementAt] may call `toElement` only once.
   ///
-  /// Equivalent to:
-  /// ```
-  /// Iterable<T> map<T>(T toElement(E e)) sync* {
-  ///   for (var value in this) {
-  ///     yield toElement(value);
-  ///   }
-  /// }
-  /// ```
   /// Example:
   /// ```dart import:convert
-  /// var products = jsonDecode('''
+  /// var products = EmpireListProperty(
   /// [
   ///   {"name": "Screwdriver", "price": 42.00},
   ///   {"name": "Wingnut", "price": 0.50}
-  /// ]
-  /// ''');
+  /// ]);
   /// var values = products.map((product) => product['price'] as double);
   /// var totalPrice = values.fold(0.0, (a, b) => a + b); // 42.5.
   /// ```
@@ -235,7 +304,7 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   ///
   /// Example:
   /// ```dart
-  /// final numbers = <int>[1, 2, 3, 5, 6, 7];
+  /// final numbers = EmpireListProperty<int>[1, 2, 3, 5, 6, 7];
   /// final elementAt = numbers.elementAt(4); // 6
   /// ```
   T elementAt(int index) {
@@ -246,7 +315,7 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   ///
   /// Example:
   /// ```dart
-  /// final numbers = <int>[1, 2, 6, 7];
+  /// final numbers = EmpireListProperty<int>[1, 2, 6, 7];
   /// numbers.forEach(print);
   /// // 1
   /// // 2
@@ -263,17 +332,38 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   /// The first time an object `o` is encountered so that `o == element`,
   /// the index of `o` is returned.
   /// ```dart
-  /// final notes = <String>['do', 're', 'mi', 're'];
+  /// final notes = EmpireListProperty<String>['do', 're', 'mi', 're'];
   /// print(notes.indexOf('re')); // 1
   ///
   /// final indexWithStart = notes.indexOf('re', 2); // 3
   /// ```
   /// Returns -1 if [value] is not found.
   /// ```dart
-  /// final notes = <String>['do', 're', 'mi', 're'];
+  /// final notes = EmpireListProperty<String>['do', 're', 'mi', 're'];
   /// final index = notes.indexOf('fa'); // -1
   /// ```
   int indexOf(T value, [int start = 0]) => _value.indexOf(value, start);
+
+  /// The first index in the list that satisfies the provided [test].
+  ///
+  /// Searches the list from index [start] to the end of the list.
+  /// The first time an object `o` is encountered so that `test(o)` is true,
+  /// the index of `o` is returned.
+  ///
+  /// ```dart
+  /// final notes = EmpireListProperty<String>(['do', 're', 'mi', 're']);
+  /// final first = notes.indexWhere((note) => note.startsWith('r')); // 1
+  /// final second = notes.indexWhere((note) => note.startsWith('r'), 2); // 3
+  /// ```
+  ///
+  /// Returns -1 if [element] is not found.
+  /// ```dart
+  /// final notes = EmpireListProperty<String>['do', 're', 'mi', 're'];
+  /// final index = notes.indexWhere((note) => note.startsWith('k')); // -1
+  /// ```
+  int indexWhere(bool Function(T element) test, [int start = 0]) {
+    return value.indexWhere(test, start);
+  }
 
   T operator [](int index) {
     return _value[index];

--- a/lib/src/empire_list_property.dart
+++ b/lib/src/empire_list_property.dart
@@ -365,6 +365,11 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
     return value.indexWhere(test, start);
   }
 
+  /// The object at the given [index] in the list.
+  ///
+  /// The [index] must be a valid index of this list,
+  /// which means that `index` must be non-negative and
+  /// less than [length].
   T operator [](int index) {
     return _value[index];
   }

--- a/lib/src/empire_map_property.dart
+++ b/lib/src/empire_map_property.dart
@@ -94,7 +94,7 @@ class EmpireMapProperty<K, V> extends EmpireProperty<Map<K, V>> {
   /// The operation is equivalent to doing `this[entry.key] = entry.value`
   /// for each [MapEntry] of the iterable.
   /// ```dart
-  /// final planets = <int, String>{1: 'Mercury', 2: 'Venus',
+  /// final planets = EmpireMapProperty<int, String>{1: 'Mercury', 2: 'Venus',
   ///   3: 'Earth', 4: 'Mars'};
   /// final gasGiants = <int, String>{5: 'Jupiter', 6: 'Saturn'};
   /// final iceGiants = <int, String>{7: 'Uranus', 8: 'Neptune'};
@@ -148,7 +148,7 @@ class EmpireMapProperty<K, V> extends EmpireProperty<Map<K, V>> {
   /// planetsFromSun.update(2, (value) => 'Venus');
   /// print(planetsFromSun); // {1: Mercury, 2: Venus, 3: Earth}
   ///
-  /// final largestPlanets = <int, String>{1: 'Jupiter', 2: 'Saturn',
+  /// final largestPlanets = EmpireMapProperty<int, String>{1: 'Jupiter', 2: 'Saturn',
   ///   3: 'Neptune'};
   /// // Key value 8 is missing from list, add it using [ifAbsent].
   /// largestPlanets.update(8, (value) => 'New', ifAbsent: () => 'Mercury');
@@ -178,7 +178,7 @@ class EmpireMapProperty<K, V> extends EmpireProperty<Map<K, V>> {
   /// Iterates over all entries in the map and updates them with the result
   /// of invoking [update].
   /// ```dart
-  /// final terrestrial = <int, String>{1: 'Mercury', 2: 'Venus', 3: 'Earth'};
+  /// final terrestrial = EmpireMapProperty<int, String>{1: 'Mercury', 2: 'Venus', 3: 'Earth'};
   /// terrestrial.updateAll((key, value) => value.toUpperCase());
   /// print(terrestrial); // {1: MERCURY, 2: VENUS, 3: EARTH}
   /// ```
@@ -211,7 +211,7 @@ class EmpireMapProperty<K, V> extends EmpireProperty<Map<K, V>> {
   /// Note that some maps allow `null` as a value,
   /// so a returned `null` value doesn't always mean that the key was absent.
   /// ```dart
-  /// final terrestrial = <int, String>{1: 'Mercury', 2: 'Venus', 3: 'Earth'};
+  /// final terrestrial = EmpireMapProperty<int, String>{1: 'Mercury', 2: 'Venus', 3: 'Earth'};
   /// final removedValue = terrestrial.remove(2); // Venus
   /// print(terrestrial); // {1: Mercury, 3: Earth}
   /// ```
@@ -233,7 +233,7 @@ class EmpireMapProperty<K, V> extends EmpireProperty<Map<K, V>> {
 
   /// Removes all entries of this map that satisfy the given [test].
   /// ```dart
-  /// final terrestrial = <int, String>{1: 'Mercury', 2: 'Venus', 3: 'Earth'};
+  /// final terrestrial = EmpireMapProperty<int, String>{1: 'Mercury', 2: 'Venus', 3: 'Earth'};
   /// terrestrial.removeWhere((key, value) => value.startsWith('E'));
   /// print(terrestrial); // {1: Mercury, 2: Venus}
   /// ```
@@ -264,7 +264,7 @@ class EmpireMapProperty<K, V> extends EmpireProperty<Map<K, V>> {
   ///
   /// After this, the map is empty.
   /// ```dart
-  /// final planets = <int, String>{1: 'Mercury', 2: 'Venus', 3: 'Earth'};
+  /// final planets = EmpireMapProperty<int, String>{1: 'Mercury', 2: 'Venus', 3: 'Earth'};
   /// planets.clear(); // {}
   /// ```
   void clear({bool notifyChanges = true}) {
@@ -283,7 +283,7 @@ class EmpireMapProperty<K, V> extends EmpireProperty<Map<K, V>> {
   /// Returns true if any of the keys in the map are equal to `key`
   /// according to the equality used by the map.
   /// ```dart
-  /// final moonCount = <String, int>{'Mercury': 0, 'Venus': 0, 'Earth': 1,
+  /// final moonCount = EmpireMapProperty<String, int>{'Mercury': 0, 'Venus': 0, 'Earth': 1,
   ///   'Mars': 2, 'Jupiter': 79, 'Saturn': 82, 'Uranus': 27, 'Neptune': 14 };
   /// final containsUranus = moonCount.containsKey('Uranus'); // true
   /// final containsPluto = moonCount.containsKey('Pluto'); // false
@@ -295,7 +295,7 @@ class EmpireMapProperty<K, V> extends EmpireProperty<Map<K, V>> {
   /// Returns true if any of the values in the map are equal to `value`
   /// according to the `==` operator.
   /// ```dart
-  /// final moonCount = <String, int>{'Mercury': 0, 'Venus': 0, 'Earth': 1,
+  /// final moonCount = EmpireMapProperty<String, int>{'Mercury': 0, 'Venus': 0, 'Earth': 1,
   ///   'Mars': 2, 'Jupiter': 79, 'Saturn': 82, 'Uranus': 27, 'Neptune': 14 };
   /// final moons3 = moonCount.containsValue(3); // false
   /// final moons82 = moonCount.containsValue(82); // true
@@ -312,7 +312,7 @@ class EmpireMapProperty<K, V> extends EmpireProperty<Map<K, V>> {
   ///
   /// Calling `action` must not add or remove keys from the map.
   /// ```dart
-  /// final planetsByMass = <num, String>{0.81: 'Venus', 1: 'Earth',
+  /// final planetsByMass = EmpireMapProperty<num, String>{0.81: 'Venus', 1: 'Earth',
   ///   0.11: 'Mars', 17.15: 'Neptune'};
   ///
   /// planetsByMass.forEach((key, value) {

--- a/lib/src/empire_string_property.dart
+++ b/lib/src/empire_string_property.dart
@@ -33,14 +33,14 @@ class EmpireStringProperty extends EmpireProperty<String> {
   ///
   /// Example:
   /// ```dart
-  /// const string = 'Doug';
+  /// const string = EmpireStringProperty('Doug');
   /// final containsD = string.contains('D'); // true
   /// final containsUpperCase = string.contains(RegExp(r'[A-Z]')); // true
   /// ```
   /// If [startIndex] is provided, this method matches only at or after that
   /// index:
   /// ```dart
-  /// const string = 'Doug smith';
+  /// const string = EmpireStringProperty('Doug smith');
   /// final containsD = string.contains(RegExp('D'), 0); // true
   /// final caseSensitive = string.contains(RegExp(r'[A-Z]'), 1); // false
   /// ```
@@ -52,7 +52,7 @@ class EmpireStringProperty extends EmpireProperty<String> {
   ///
   /// Example:
   /// ```dart
-  /// const string = 'dougsmith';
+  /// const string = EmpireStringProperty('dougsmith');
   /// var result = string.substring(1); // 'ougsmith'
   /// result = string.substring(1, 3); // 'oug'
   /// ```
@@ -95,14 +95,14 @@ class EmpireNullableStringProperty extends EmpireProperty<String?> {
   ///
   /// Example:
   /// ```dart
-  /// const string = 'Doug';
+  /// const string = EmpireStringProperty('Doug');
   /// final containsD = string.contains('D'); // true
   /// final containsUpperCase = string.contains(RegExp(r'[A-Z]')); // true
   /// ```
   /// If [startIndex] is provided, this method matches only at or after that
   /// index:
   /// ```dart
-  /// const string = 'Doug smith';
+  /// const string = EmpireStringProperty('Doug smith');
   /// final containsD = string.contains(RegExp('D'), 0); // true
   /// final caseSensitive = string.contains(RegExp(r'[A-Z]'), 1); // false
   /// ```
@@ -116,7 +116,7 @@ class EmpireNullableStringProperty extends EmpireProperty<String?> {
   ///
   /// Example:
   /// ```dart
-  /// const string = 'dougsmith';
+  /// const string = EmpireStringProperty('dougsmith');
   /// var result = string.substring(1); // 'ougsmith'
   /// result = string.substring(1, 3); // 'oug'
   /// ```

--- a/test/empire_property_tests/list_property_test.dart
+++ b/test/empire_property_tests/list_property_test.dart
@@ -248,5 +248,117 @@ void main() {
 
       expect(result, equals(expected));
     });
+
+    test(
+      'where - list is not empty - returns items in list matching prediate',
+      () {
+        const expectedLength = 3;
+        final expectedItems = [3, 4, 5];
+        final numbers = EmpireListProperty([1, 2, ...expectedItems]);
+        final result = numbers.where((x) => x > 2);
+
+        expect(result.length, equals(expectedLength));
+        expect(result, equals(expectedItems));
+      },
+    );
+
+    test(
+      'firstWhere - returns first matching item',
+      () {
+        const expected = 3;
+        final numbers = EmpireListProperty([1, 2, 3]);
+        final result = numbers.firstWhere((element) => element == expected);
+
+        expect(result, equals(expected));
+      },
+    );
+
+    test(
+      'firstWhere - no match found - returns result from orElse',
+      () {
+        const expected = -1;
+        final numbers = EmpireListProperty([1, 2, 3]);
+        final result = numbers.firstWhere(
+          (element) => element == expected,
+          orElse: () => expected,
+        );
+
+        expect(result, equals(expected));
+      },
+    );
+
+    test(
+      'firstWhereOrNull - match found - returns first matching item',
+      () {
+        const expected = 3;
+        final numbers = EmpireListProperty([1, 2, 3]);
+        final result =
+            numbers.firstWhereOrNull((element) => element == expected);
+
+        expect(result, equals(expected));
+      },
+    );
+
+    test(
+      'firstWhereOrNull - no match found - returns null',
+      () {
+        const expected = -1;
+        final numbers = EmpireListProperty([1, 2, 3]);
+        final result =
+            numbers.firstWhereOrNull((element) => element == expected);
+
+        expect(result, isNull);
+      },
+    );
+
+    test(
+      'indexWhere - match found - returns correct index',
+      () {
+        const expected = 2;
+        final numbers = EmpireListProperty([1, 2, 3]);
+        final result = numbers.indexWhere((element) => element == 3);
+
+        expect(result, equals(expected));
+      },
+    );
+
+    test(
+      'indexWhere - no match found - returns -1',
+      () {
+        const expected = -1;
+        final numbers = EmpireListProperty([1, 2, 3]);
+        final result = numbers.indexWhere((element) => element == expected);
+
+        expect(result, equals(expected));
+      },
+    );
+
+    test('reversed - returns reversed list', () {
+      final expected = [3, 2, 1];
+      final numbers = EmpireListProperty([1, 2, 3]);
+      final reversed = numbers.reversed;
+      expect(reversed, equals(expected));
+    });
+
+    test('first - list is not empty - returns first item', () {
+      const expected = 1;
+      final numbers = EmpireListProperty([1, 2, 3]);
+      final first = numbers.first;
+      expect(first, equals(expected));
+    });
+
+    test('last - list is not empty - returns last item', () {
+      const expected = 3;
+      final numbers = EmpireListProperty([1, 2, 3]);
+      final last = numbers.last;
+      expect(last, equals(expected));
+    });
+
+    test('single - list contains one item - returns item', () {
+      const expected = 1;
+      final numbers = EmpireListProperty([expected]);
+      final single = numbers.single;
+      expect(single, equals(expected));
+    });
   });
 }


### PR DESCRIPTION
resolves #78 

- Added the following read-only properties to EmpireListProperty
-- `first`
-- `last`
-- `reversed`
-- `single`

- Added the following new functions to EmpireListProperty
-- `where`
-- `firstWhere`
-- `firstWhereOrNull`

- Fix documentation in most empire properties files