### PR TITLE
EmpireIntProperty and EmpireDoubleProperty Arithmetic Fixes

### DIFF
--- a/example/lib/counter_view_model.dart
+++ b/example/lib/counter_view_model.dart
@@ -10,7 +10,7 @@ class CounterViewModel extends EmpireViewModel {
   }
 
   Future<void> incrementCounter() async {
-    count(count + 1);
+    count.increment();
   }
 
   void reset() {

--- a/lib/src/empire_double_property.dart
+++ b/lib/src/empire_double_property.dart
@@ -1,36 +1,36 @@
 part of 'empire_property.dart';
 
-///An [EmpireProperty] with similar characteristics of dart [double] objects
+/// An [EmpireProperty] with similar characteristics of dart [double] objects
 ///
-///The underlying value cannot be null. For a nullable double empire property,
-///use the [EmpireNullableDoubleProperty].
+/// The underlying value cannot be null. For a nullable double empire property,
+/// use the [EmpireNullableDoubleProperty].
 ///
-///You can perform most arithmetic operator on this (+, -, /, *).
+/// You can perform most arithmetic operator on this (+, -, /, *).
 ///
-///Unary operators are not supported (++, --, +=, -=, etc)
+/// Unary operators are not supported (++, --, +=, -=, etc)
 ///
-///When the value of this changes, it will send a [EmpireStateChanged] event by default. This includes
-///automatically triggering a UI rebuild.
+/// When the value of this changes, it will send a [EmpireStateChanged] event by default. This includes
+/// automatically triggering a UI rebuild.
 ///
-///Example
-///```dart
+/// Example
+/// ```dart
 ///
-///final percentage = EmpireDoubleProperty(10.0);
+/// final percentage = EmpireDoubleProperty(10.0);
 ///
-///print('${percentage + 5.2}'); //prints 15.2
-///```
+/// print('${percentage + 5.2}'); //prints 15.2
+/// ```
 class EmpireDoubleProperty extends EmpireProperty<double> {
   EmpireDoubleProperty(super.value, {super.propertyName});
 
-  ///Factory constructor for initializing an [EmpireDoubleProperty] to zero.
+  /// Factory constructor for initializing an [EmpireDoubleProperty] to zero.
   ///
-  ///See [EmpireProperty] for [propertyName] usages.
+  /// See [EmpireProperty] for [propertyName] usages.
   ///
-  ///## Example
+  /// ## Example
   ///
-  ///```dart
-  ///final bankAccountBalance = EmpireDoubleProperty.zero();
-  ///```
+  /// ```dart
+  /// final bankAccountBalance = EmpireDoubleProperty.zero();
+  /// ```
   factory EmpireDoubleProperty.zero({String? propertyName}) {
     return EmpireDoubleProperty(0, propertyName: propertyName);
   }
@@ -86,7 +86,7 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
 
   /// Adds [other] to this number.
   ///
-  ///This does not set the value for this [EmpireDoubleProperty].
+  /// This does not set the value for this [EmpireDoubleProperty].
   ///
   /// The result is an [double], as described by [double.+]
   double add<E extends num>(E other) {
@@ -95,7 +95,7 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
 
   /// Subtracts [other] from this number.
   ///
-  ///This does not set the value for this [EmpireDoubleProperty].
+  /// This does not set the value for this [EmpireDoubleProperty].
   ///
   /// The result is an [double], as described by [double.-]
   double subtract<E extends num>(E other) {
@@ -104,7 +104,7 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
 
   /// Divides this number by [other].
   ///
-  ///This does not set the value for this [EmpireDoubleProperty].
+  /// This does not set the value for this [EmpireDoubleProperty].
   ///
   /// The result is an [double], as described by [double./]
   double divide<E extends num>(E other) {
@@ -113,7 +113,7 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
 
   /// Euclidean modulo of this number by [other].
   ///
-  ///This does not set the value for this [EmpireDoubleProperty].
+  /// This does not set the value for this [EmpireDoubleProperty].
   ///
   /// Returns the remainder of the Euclidean division.
   /// The Euclidean division of two integers `a` and `b`
@@ -140,7 +140,7 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
 
   /// Multiplies this number by [other].
   ///
-  ///This does not set the value for this [EmpireDoubleProperty].
+  /// This does not set the value for this [EmpireDoubleProperty].
   ///
   /// The result is an [double], as described by [double.*]
   double multiply<E extends num>(E other) {
@@ -148,43 +148,43 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
   }
 }
 
-///An [EmpireProperty] with similar characteristics of dart [double] objects
+/// An [EmpireProperty] with similar characteristics of dart [double] objects
 ///
-///The underlying value *can* be null.
+/// The underlying value *can* be null.
 ///
-///You can perform most arithmetic operator on this (+, -, /, *).
-///If the underlying value of this is null and an arithmetic operator is called on this,
-///it will throw a [EmpirePropertyNullValueException].
+/// You can perform most arithmetic operator on this (+, -, /, *).
+/// If the underlying value of this is null and an arithmetic operator is called on this,
+/// it will throw a [EmpirePropertyNullValueException].
 ///
-///Unary operators are not supported (++, --, +=, -=, etc)
+/// Unary operators are not supported (++, --, +=, -=, etc)
 ///
-///You can easily check for null by accessing the [isNull] or [isNotNull] properties.
+/// You can easily check for null by accessing the [isNull] or [isNotNull] properties.
 ///
-///When the value of this changes, it will send a [EmpireStateChanged] event by default. This includes
-///automatically triggering a UI rebuild.
+/// When the value of this changes, it will send a [EmpireStateChanged] event by default. This includes
+/// automatically triggering a UI rebuild.
 ///
-///Example
-///```dart
-///final percentage = EmpireNullableDoubleProperty(10.0);
+/// Example
+/// ```dart
+/// final percentage = EmpireNullableDoubleProperty(10.0);
 ///
-///if (percentage.isNull)
-///{
-///   print("I'm Null");
-///}
-///```
+/// if (percentage.isNull)
+/// {
+///    print("I'm Null");
+/// }
+/// ```
 ///
-///Other Usages Examples
-///```dart
+/// Other Usages Examples
+/// ```dart
 ///
-///final percentage = EmpireNullableDoubleProperty();
+/// final percentage = EmpireNullableDoubleProperty();
 ///
-///print('${percentage + 5.2}'); //throws EmpireNullValueException because no value has been set yet.
+/// print('${percentage + 5.2}'); //throws EmpireNullValueException because no value has been set yet.
 ///
-///percentage(10.0)
+/// percentage(10.0)
 ///
-///print('${percentage - 0.5}'); //prints 9.5
+/// print('${percentage - 0.5}'); //prints 9.5
 ///
-///```
+/// ```
 ///
 class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
   EmpireNullableDoubleProperty({double? value, super.propertyName})
@@ -253,7 +253,7 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
 
   /// Adds [other] to this number.
   ///
-  ///This does not set the value for this [EmpireNullableDoubleProperty].
+  /// This does not set the value for this [EmpireNullableDoubleProperty].
   ///
   /// The result is an [double], as described by [double.+].
   /// If the underlying value is [null] throws an [EmpirePropertyNullValueException].
@@ -266,7 +266,7 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
 
   /// Subtracts [other] from this number.
   ///
-  ///This does not set the value for this [EmpireNullableDoubleProperty].
+  /// This does not set the value for this [EmpireNullableDoubleProperty].
   ///
   /// The result is an [double], as described by [double.-],
   /// If the underlying value is [null] throws an [EmpirePropertyNullValueException].
@@ -279,7 +279,7 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
 
   /// Divides this number by [other].
   ///
-  ///This does not set the value for this [EmpireNullableDoubleProperty].
+  /// This does not set the value for this [EmpireNullableDoubleProperty].
   ///
   /// The result is an [double], as described by [double./],
   ///
@@ -293,7 +293,7 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
 
   /// Euclidean modulo of this number by [other].
   ///
-  ///This does not set the value for this [EmpireNullableDoubleProperty].
+  /// This does not set the value for this [EmpireNullableDoubleProperty].
   ///
   /// Returns the remainder of the Euclidean division.
   /// The Euclidean division of two integers `a` and `b`
@@ -325,7 +325,7 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
 
   /// Multiplies this number by [other].
   ///
-  ///This does not set the value for this [EmpireNullableDoubleProperty].
+  /// This does not set the value for this [EmpireNullableDoubleProperty].
   ///
   /// The result is an [double], as described by [double.*],
   /// If the underlying value is [null] throws an [EmpirePropertyNullValueException].

--- a/lib/src/empire_double_property.dart
+++ b/lib/src/empire_double_property.dart
@@ -88,9 +88,7 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
   ///
   ///This does not set the value for this [EmpireDoubleProperty].
   ///
-  /// The result is an [int], as described by [int.+],
-  /// if both this number and [other] is an integer,
-  /// otherwise the result is a [double].
+  /// The result is an [double], as described by [double.+]
   double add<E extends num>(E other) {
     return _value + other;
   }
@@ -99,9 +97,7 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
   ///
   ///This does not set the value for this [EmpireDoubleProperty].
   ///
-  /// The result is an [int], as described by [int.-],
-  /// if both this number and [other] is an integer,
-  /// otherwise the result is a [double].
+  /// The result is an [double], as described by [double.-]
   double subtract<E extends num>(E other) {
     return _value - other;
   }
@@ -109,6 +105,8 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
   /// Divides this number by [other].
   ///
   ///This does not set the value for this [EmpireDoubleProperty].
+  ///
+  /// The result is an [double], as described by [double./]
   double divide<E extends num>(E other) {
     return _value / other;
   }
@@ -129,9 +127,7 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
   /// The sign of the returned value `r` is always positive.
   ///
   ///
-  /// The result is an [int], as described by [int.%],
-  /// if both this number and [other] are integers,
-  /// otherwise the result is a [double].
+  /// The result is an [double], as described by [double.%]
   ///
   /// Example:
   /// ```dart
@@ -146,9 +142,7 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
   ///
   ///This does not set the value for this [EmpireDoubleProperty].
   ///
-  /// The result is an [int], as described by [int.*],
-  /// if both this number and [other] are integers,
-  /// otherwise the result is a [double].
+  /// The result is an [double], as described by [double.*]
   double multiply<E extends num>(E other) {
     return _value * other;
   }
@@ -261,9 +255,8 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
   ///
   ///This does not set the value for this [EmpireNullableDoubleProperty].
   ///
-  /// The result is an [int], as described by [int.+],
-  /// if both this number and [other] is an integer,
-  /// otherwise the result is a [double].
+  /// The result is an [double], as described by [double.+].
+  /// If the underlying value is [null] throws an [EmpirePropertyNullValueException].
   double add<E extends num>(E other) {
     return isNotNull
         ? _value! + other
@@ -275,9 +268,8 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
   ///
   ///This does not set the value for this [EmpireNullableDoubleProperty].
   ///
-  /// The result is an [int], as described by [int.-],
-  /// if both this number and [other] is an integer,
-  /// otherwise the result is a [double].
+  /// The result is an [double], as described by [double.-],
+  /// If the underlying value is [null] throws an [EmpirePropertyNullValueException].
   double subtract<E extends num>(E other) {
     return isNotNull
         ? _value! - other
@@ -288,6 +280,10 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
   /// Divides this number by [other].
   ///
   ///This does not set the value for this [EmpireNullableDoubleProperty].
+  ///
+  /// The result is an [double], as described by [double./],
+  ///
+  /// If the underlying value is [null] throws an [EmpirePropertyNullValueException].
   double divide<E extends num>(E other) {
     return isNotNull
         ? _value! / other
@@ -311,9 +307,9 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
   /// The sign of the returned value `r` is always positive.
   ///
   ///
-  /// The result is an [int], as described by [int.%],
-  /// if both this number and [other] are integers,
-  /// otherwise the result is a [double].
+  /// The result is an [double], as described by [double.%]
+  ///
+  /// If the underlying value is [null] throws an [EmpirePropertyNullValueException].
   ///
   /// Example:
   /// ```dart
@@ -331,9 +327,8 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
   ///
   ///This does not set the value for this [EmpireNullableDoubleProperty].
   ///
-  /// The result is an [int], as described by [int.*],
-  /// if both this number and [other] are integers,
-  /// otherwise the result is a [double].
+  /// The result is an [double], as described by [double.*],
+  /// If the underlying value is [null] throws an [EmpirePropertyNullValueException].
   double multiply<E extends num>(E other) {
     return isNotNull
         ? _value! * other

--- a/lib/src/empire_double_property.dart
+++ b/lib/src/empire_double_property.dart
@@ -84,15 +84,74 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
   /// ```
   double roundToDouble() => _value.roundToDouble();
 
-  double operator +(other) => value + other;
+  /// Adds [other] to this number.
+  ///
+  ///This does not set the value for this [EmpireDoubleProperty].
+  ///
+  /// The result is an [int], as described by [int.+],
+  /// if both this number and [other] is an integer,
+  /// otherwise the result is a [double].
+  double add<E extends num>(E other) {
+    return _value + other;
+  }
 
-  double operator -(other) => value - other;
+  /// Subtracts [other] from this number.
+  ///
+  ///This does not set the value for this [EmpireDoubleProperty].
+  ///
+  /// The result is an [int], as described by [int.-],
+  /// if both this number and [other] is an integer,
+  /// otherwise the result is a [double].
+  double subtract<E extends num>(E other) {
+    return _value - other;
+  }
 
-  double operator /(other) => value / other;
+  /// Divides this number by [other].
+  ///
+  ///This does not set the value for this [EmpireDoubleProperty].
+  double divide<E extends num>(E other) {
+    return _value / other;
+  }
 
-  double operator %(other) => value % other;
+  /// Euclidean modulo of this number by [other].
+  ///
+  ///This does not set the value for this [EmpireDoubleProperty].
+  ///
+  /// Returns the remainder of the Euclidean division.
+  /// The Euclidean division of two integers `a` and `b`
+  /// yields two integers `q` and `r` such that
+  /// `a == b * q + r` and `0 <= r < b.abs()`.
+  ///
+  /// The Euclidean division is only defined for integers, but can be easily
+  /// extended to work with doubles. In that case, `q` is still an integer,
+  /// but `r` may have a non-integer value that still satisfies `0 <= r < |b|`.
+  ///
+  /// The sign of the returned value `r` is always positive.
+  ///
+  ///
+  /// The result is an [int], as described by [int.%],
+  /// if both this number and [other] are integers,
+  /// otherwise the result is a [double].
+  ///
+  /// Example:
+  /// ```dart
+  /// final number = EmpireDoubleProperty(5.0);
+  /// print(number % 3); // 2.0
+  /// ```
+  double mod<E extends num>(E other) {
+    return _value % other;
+  }
 
-  double operator *(other) => value * other;
+  /// Multiplies this number by [other].
+  ///
+  ///This does not set the value for this [EmpireDoubleProperty].
+  ///
+  /// The result is an [int], as described by [int.*],
+  /// if both this number and [other] are integers,
+  /// otherwise the result is a [double].
+  double multiply<E extends num>(E other) {
+    return _value * other;
+  }
 }
 
 ///An [EmpireProperty] with similar characteristics of dart [double] objects
@@ -161,7 +220,7 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
   /// Throws an [UnsupportedError] if this number is not finite
   /// (NaN or an infinity).
   /// ```dart
-  /// final number = EmpireDoubleProperty(3.25);
+  /// final number = EmpireNullableDoubleProperty(3.25);
   /// print(number.round()); // 3
   ///
   /// number(3.5);
@@ -187,7 +246,7 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
   /// This means that for a value `d` in the range `-0.5 < d < 0.0`,
   /// the result is `-0.0`.
   /// ```dart
-  /// final number = EmpireDoubleProperty(3.25);
+  /// final number = EmpireNullableDoubleProperty(3.25);
   /// print(number.roundToDouble()); // 3.0
   ///
   /// number(3.5);
@@ -198,28 +257,87 @@ class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
   /// ```
   double? roundToDouble() => _value?.roundToDouble();
 
-  double operator +(other) => isNotNull
-      ? value! + other!
-      : throw EmpirePropertyNullValueException(
-          StackTrace.current, propertyName, runtimeType);
+  /// Adds [other] to this number.
+  ///
+  ///This does not set the value for this [EmpireNullableDoubleProperty].
+  ///
+  /// The result is an [int], as described by [int.+],
+  /// if both this number and [other] is an integer,
+  /// otherwise the result is a [double].
+  double add<E extends num>(E other) {
+    return isNotNull
+        ? _value! + other
+        : throw EmpirePropertyNullValueException(
+            StackTrace.current, propertyName, runtimeType);
+  }
 
-  double operator -(other) => isNotNull
-      ? value! - other!
-      : throw EmpirePropertyNullValueException(
-          StackTrace.current, propertyName, runtimeType);
+  /// Subtracts [other] from this number.
+  ///
+  ///This does not set the value for this [EmpireNullableDoubleProperty].
+  ///
+  /// The result is an [int], as described by [int.-],
+  /// if both this number and [other] is an integer,
+  /// otherwise the result is a [double].
+  double subtract<E extends num>(E other) {
+    return isNotNull
+        ? _value! - other
+        : throw EmpirePropertyNullValueException(
+            StackTrace.current, propertyName, runtimeType);
+  }
 
-  double operator /(other) => isNotNull
-      ? value! / other!
-      : throw EmpirePropertyNullValueException(
-          StackTrace.current, propertyName, runtimeType);
+  /// Divides this number by [other].
+  ///
+  ///This does not set the value for this [EmpireNullableDoubleProperty].
+  double divide<E extends num>(E other) {
+    return isNotNull
+        ? _value! / other
+        : throw EmpirePropertyNullValueException(
+            StackTrace.current, propertyName, runtimeType);
+  }
 
-  double operator %(other) => isNotNull
-      ? value! % other!
-      : throw EmpirePropertyNullValueException(
-          StackTrace.current, propertyName, runtimeType);
+  /// Euclidean modulo of this number by [other].
+  ///
+  ///This does not set the value for this [EmpireNullableDoubleProperty].
+  ///
+  /// Returns the remainder of the Euclidean division.
+  /// The Euclidean division of two integers `a` and `b`
+  /// yields two integers `q` and `r` such that
+  /// `a == b * q + r` and `0 <= r < b.abs()`.
+  ///
+  /// The Euclidean division is only defined for integers, but can be easily
+  /// extended to work with doubles. In that case, `q` is still an integer,
+  /// but `r` may have a non-integer value that still satisfies `0 <= r < |b|`.
+  ///
+  /// The sign of the returned value `r` is always positive.
+  ///
+  ///
+  /// The result is an [int], as described by [int.%],
+  /// if both this number and [other] are integers,
+  /// otherwise the result is a [double].
+  ///
+  /// Example:
+  /// ```dart
+  /// final number = EmpireNullableDoubleProperty(5);
+  /// print(number % 3); // 2.0
+  /// ```
+  double mod<E extends num>(E other) {
+    return isNotNull
+        ? _value! % other
+        : throw EmpirePropertyNullValueException(
+            StackTrace.current, propertyName, runtimeType);
+  }
 
-  double operator *(other) => isNotNull
-      ? value! * other!
-      : throw EmpirePropertyNullValueException(
-          StackTrace.current, propertyName, runtimeType);
+  /// Multiplies this number by [other].
+  ///
+  ///This does not set the value for this [EmpireNullableDoubleProperty].
+  ///
+  /// The result is an [int], as described by [int.*],
+  /// if both this number and [other] are integers,
+  /// otherwise the result is a [double].
+  double multiply<E extends num>(E other) {
+    return isNotNull
+        ? _value! * other
+        : throw EmpirePropertyNullValueException(
+            StackTrace.current, propertyName, runtimeType);
+  }
 }

--- a/lib/src/empire_int_property.dart
+++ b/lib/src/empire_int_property.dart
@@ -207,28 +207,87 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
   /// Returns null if the int value is null
   int? abs() => _value?.abs();
 
-  int operator +(other) => isNotNull
-      ? (value! + other).toInt()
-      : throw EmpirePropertyNullValueException(
-          StackTrace.current, propertyName, runtimeType);
+  /// Adds [other] to this number.
+  ///
+  ///This does not set the value for this [EmpireIntProperty].
+  ///
+  /// The result is an [int], as described by [int.+],
+  /// if both this number and [other] is an integer,
+  /// otherwise the result is a [double].
+  E add<E extends num>(E other) {
+    return isNotNull
+        ? (_value! + other) as E
+        : throw EmpirePropertyNullValueException(
+            StackTrace.current, propertyName, runtimeType);
+  }
 
-  int operator -(other) => isNotNull
-      ? (value! - other).toInt()
-      : throw EmpirePropertyNullValueException(
-          StackTrace.current, propertyName, runtimeType);
+  /// Subtracts [other] from this number.
+  ///
+  ///This does not set the value for this [EmpireIntProperty].
+  ///
+  /// The result is an [int], as described by [int.-],
+  /// if both this number and [other] is an integer,
+  /// otherwise the result is a [double].
+  E subtract<E extends num>(E other) {
+    return isNotNull
+        ? (_value! - other) as E
+        : throw EmpirePropertyNullValueException(
+            StackTrace.current, propertyName, runtimeType);
+  }
 
-  int operator /(other) => isNotNull
-      ? value! ~/ other!
-      : throw EmpirePropertyNullValueException(
-          StackTrace.current, propertyName, runtimeType);
+  /// Divides this number by [other].
+  ///
+  ///This does not set the value for this [EmpireIntProperty].
+  double divide<E extends num>(E other) {
+    return isNotNull
+        ? _value! / other
+        : throw EmpirePropertyNullValueException(
+            StackTrace.current, propertyName, runtimeType);
+  }
 
-  int operator %(other) => isNotNull
-      ? (value! % other).toInt()
-      : throw EmpirePropertyNullValueException(
-          StackTrace.current, propertyName, runtimeType);
+  /// Euclidean modulo of this number by [other].
+  ///
+  ///This does not set the value for this [EmpireIntProperty].
+  ///
+  /// Returns the remainder of the Euclidean division.
+  /// The Euclidean division of two integers `a` and `b`
+  /// yields two integers `q` and `r` such that
+  /// `a == b * q + r` and `0 <= r < b.abs()`.
+  ///
+  /// The Euclidean division is only defined for integers, but can be easily
+  /// extended to work with doubles. In that case, `q` is still an integer,
+  /// but `r` may have a non-integer value that still satisfies `0 <= r < |b|`.
+  ///
+  /// The sign of the returned value `r` is always positive.
+  ///
+  ///
+  /// The result is an [int], as described by [int.%],
+  /// if both this number and [other] are integers,
+  /// otherwise the result is a [double].
+  ///
+  /// Example:
+  /// ```dart
+  /// final number = EmpireIntProperty(5);
+  /// print(number % 3); // 2
+  /// ```
+  E mod<E extends num>(E other) {
+    return isNotNull
+        ? (_value! % other) as E
+        : throw EmpirePropertyNullValueException(
+            StackTrace.current, propertyName, runtimeType);
+  }
 
-  int operator *(other) => isNotNull
-      ? (value! * other).toInt()
-      : throw EmpirePropertyNullValueException(
-          StackTrace.current, propertyName, runtimeType);
+  /// Multiplies this number by [other].
+  ///
+  ///This does not set the value for this [EmpireIntProperty].
+  ///
+  /// The result is an [int], as described by [int.*],
+  /// if both this number and [other] are integers,
+  /// otherwise the result is a [double].
+  E multiply<E extends num>(E other) {
+    return isNotNull
+        ? (_value! * other) as E
+        : throw EmpirePropertyNullValueException(
+            StackTrace.current, propertyName, runtimeType);
+  }
 }

--- a/lib/src/empire_int_property.dart
+++ b/lib/src/empire_int_property.dart
@@ -60,15 +60,74 @@ class EmpireIntProperty extends EmpireProperty<int> {
   /// Returns the absolute value of this integer.
   int abs() => _value.abs();
 
-  int operator +(other) => (value + other).toInt();
+  /// Adds [other] to this number.
+  ///
+  ///This does not set the value for this [EmpireIntProperty].
+  ///
+  /// The result is an [int], as described by [int.+],
+  /// if both this number and [other] is an integer,
+  /// otherwise the result is a [double].
+  E add<E extends num>(E other) {
+    return (_value + other) as E;
+  }
 
-  int operator -(other) => (value - other).toInt();
+  /// Subtracts [other] from this number.
+  ///
+  ///This does not set the value for this [EmpireIntProperty].
+  ///
+  /// The result is an [int], as described by [int.-],
+  /// if both this number and [other] is an integer,
+  /// otherwise the result is a [double].
+  E subtract<E extends num>(E other) {
+    return (_value - other) as E;
+  }
 
-  int operator /(other) => value ~/ other;
+  /// Divides this number by [other].
+  ///
+  ///This does not set the value for this [EmpireIntProperty].
+  double divide<E extends num>(E other) {
+    return _value / other;
+  }
 
-  int operator %(other) => (value % other).toInt();
+  /// Euclidean modulo of this number by [other].
+  ///
+  ///This does not set the value for this [EmpireIntProperty].
+  ///
+  /// Returns the remainder of the Euclidean division.
+  /// The Euclidean division of two integers `a` and `b`
+  /// yields two integers `q` and `r` such that
+  /// `a == b * q + r` and `0 <= r < b.abs()`.
+  ///
+  /// The Euclidean division is only defined for integers, but can be easily
+  /// extended to work with doubles. In that case, `q` is still an integer,
+  /// but `r` may have a non-integer value that still satisfies `0 <= r < |b|`.
+  ///
+  /// The sign of the returned value `r` is always positive.
+  ///
+  ///
+  /// The result is an [int], as described by [int.%],
+  /// if both this number and [other] are integers,
+  /// otherwise the result is a [double].
+  ///
+  /// Example:
+  /// ```dart
+  /// final number = EmpireIntProperty(5);
+  /// print(number % 3); // 2
+  /// ```
+  E mod<E extends num>(E other) {
+    return (_value % other) as E;
+  }
 
-  int operator *(other) => (value * other).toInt();
+  /// Multiplies this number by [other].
+  ///
+  ///This does not set the value for this [EmpireIntProperty].
+  ///
+  /// The result is an [int], as described by [int.*],
+  /// if both this number and [other] are integers,
+  /// otherwise the result is a [double].
+  E multiply<E extends num>(E other) {
+    return (_value * other) as E;
+  }
 }
 
 ///An [EmpireProperty] with similar characteristics of dart [int] objects

--- a/lib/src/empire_int_property.dart
+++ b/lib/src/empire_int_property.dart
@@ -209,7 +209,7 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
 
   /// Adds [other] to this number.
   ///
-  ///This does not set the value for this [EmpireIntProperty].
+  ///This does not set the value for this [EmpireNullableIntProperty].
   ///
   /// The result is an [int], as described by [int.+],
   /// if both this number and [other] is an integer,
@@ -223,7 +223,7 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
 
   /// Subtracts [other] from this number.
   ///
-  ///This does not set the value for this [EmpireIntProperty].
+  ///This does not set the value for this [EmpireNullableIntProperty].
   ///
   /// The result is an [int], as described by [int.-],
   /// if both this number and [other] is an integer,
@@ -237,7 +237,7 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
 
   /// Divides this number by [other].
   ///
-  ///This does not set the value for this [EmpireIntProperty].
+  ///This does not set the value for this [EmpireNullableIntProperty].
   double divide<E extends num>(E other) {
     return isNotNull
         ? _value! / other
@@ -247,7 +247,7 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
 
   /// Euclidean modulo of this number by [other].
   ///
-  ///This does not set the value for this [EmpireIntProperty].
+  ///This does not set the value for this [EmpireNullableIntProperty].
   ///
   /// Returns the remainder of the Euclidean division.
   /// The Euclidean division of two integers `a` and `b`
@@ -267,7 +267,7 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
   ///
   /// Example:
   /// ```dart
-  /// final number = EmpireIntProperty(5);
+  /// final number = EmpireNullableIntProperty(5);
   /// print(number % 3); // 2
   /// ```
   E mod<E extends num>(E other) {
@@ -279,7 +279,7 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
 
   /// Multiplies this number by [other].
   ///
-  ///This does not set the value for this [EmpireIntProperty].
+  ///This does not set the value for this [EmpireNullableIntProperty].
   ///
   /// The result is an [int], as described by [int.*],
   /// if both this number and [other] are integers,

--- a/lib/src/empire_int_property.dart
+++ b/lib/src/empire_int_property.dart
@@ -1,36 +1,36 @@
 part of 'empire_property.dart';
 
-///An [EmpireProperty] with similar characteristics of dart [int] objects
+/// An [EmpireProperty] with similar characteristics of dart [int] objects
 ///
-///The underlying value cannot be null. For a nullable int empire property,
-///use the [EmpireNullableIntProperty].
+/// The underlying value cannot be null. For a nullable int empire property,
+/// use the [EmpireNullableIntProperty].
 ///
-///You can perform most arithmetic operator on this (+, -, /, *).
+/// You can perform most arithmetic operator on this (+, -, /, *).
 ///
-///Unary operators are not supported (++, --, +=, -=, etc)
+/// Unary operators are not supported (++, --, +=, -=, etc)
 ///
-///When the value of this changes, it will send a [EmpireStateChanged] event by default. This includes
-///automatically triggering a UI rebuild.
+/// When the value of this changes, it will send a [EmpireStateChanged] event by default. This includes
+/// automatically triggering a UI rebuild.
 ///
-///Example
-///```dart
+/// Example
+/// ```dart
 ///
-//final age = EmpireIntProperty(10);
+/// final age = EmpireIntProperty(10);
 ///
-///print('${age + 5}'); //prints 15
-///```
+/// print('${age + 5}'); //prints 15
+/// ```
 class EmpireIntProperty extends EmpireProperty<int> {
   EmpireIntProperty(super.value, {super.propertyName});
 
-  ///Factory constructor for initializing an [EmpireIntProperty] to zero.
+  /// Factory constructor for initializing an [EmpireIntProperty] to zero.
   ///
-  ///See [EmpireProperty] for [propertyName] usages.
+  /// See [EmpireProperty] for [propertyName] usages.
   ///
-  ///## Example
+  /// ## Example
   ///
-  ///```dart
-  ///final numberOfFriends = EmpireIntProperty.zero();
-  ///```
+  /// ```dart
+  /// final numberOfFriends = EmpireIntProperty.zero();
+  /// ```
   factory EmpireIntProperty.zero({String? propertyName}) {
     return EmpireIntProperty(0, propertyName: propertyName);
   }
@@ -60,7 +60,7 @@ class EmpireIntProperty extends EmpireProperty<int> {
 
   /// Adds [other] to this number.
   ///
-  ///This does not set the value for this [EmpireIntProperty].
+  /// This does not set the value for this [EmpireIntProperty].
   ///
   /// The result is an [int], as described by [int.+],
   /// if both this number and [other] is an integer,
@@ -71,7 +71,7 @@ class EmpireIntProperty extends EmpireProperty<int> {
 
   /// Subtracts [other] from this number.
   ///
-  ///This does not set the value for this [EmpireIntProperty].
+  /// This does not set the value for this [EmpireIntProperty].
   ///
   /// The result is an [int], as described by [int.-],
   /// if both this number and [other] is an integer,
@@ -82,14 +82,14 @@ class EmpireIntProperty extends EmpireProperty<int> {
 
   /// Divides this number by [other].
   ///
-  ///This does not set the value for this [EmpireIntProperty].
+  /// This does not set the value for this [EmpireIntProperty].
   double divide<E extends num>(E other) {
     return _value / other;
   }
 
   /// Euclidean modulo of this number by [other].
   ///
-  ///This does not set the value for this [EmpireIntProperty].
+  /// This does not set the value for this [EmpireIntProperty].
   ///
   /// Returns the remainder of the Euclidean division.
   /// The Euclidean division of two integers `a` and `b`
@@ -118,7 +118,7 @@ class EmpireIntProperty extends EmpireProperty<int> {
 
   /// Multiplies this number by [other].
   ///
-  ///This does not set the value for this [EmpireIntProperty].
+  /// This does not set the value for this [EmpireIntProperty].
   ///
   /// The result is an [int], as described by [int.*],
   /// if both this number and [other] are integers,
@@ -128,56 +128,56 @@ class EmpireIntProperty extends EmpireProperty<int> {
   }
 }
 
-///An [EmpireProperty] with similar characteristics of dart [int] objects
+/// An [EmpireProperty] with similar characteristics of dart [int] objects
 ///
-///The underlying value *can* be null.
+/// The underlying value *can* be null.
 ///
-///You can perform most arithmetic operator on this (+, -, /, *).
-///If the underlying value of this is null and an arithmetic operator is called on this,
-///it will throw a [EmpirePropertyNullValueException].
+/// You can perform most arithmetic operator on this (+, -, /, *).
+/// If the underlying value of this is null and an arithmetic operator is called on this,
+/// it will throw a [EmpirePropertyNullValueException].
 ///
-///Unary operators are not supported (++, --, +=, -=, etc)
+/// Unary operators are not supported (++, --, +=, -=, etc)
 ///
-///You can easily check for null by accessing the [isNull] or [isNotNull] properties.
+/// You can easily check for null by accessing the [isNull] or [isNotNull] properties.
 ///
-///When the value of this changes, it will send a [EmpireStateChanged] event by default. This includes
-///automatically triggering a UI rebuild.
+/// When the value of this changes, it will send a [EmpireStateChanged] event by default. This includes
+/// automatically triggering a UI rebuild.
 ///
-///Example
-///```dart
-///final age = EmpireNullableIntProperty();
+/// Example
+/// ```dart
+/// final age = EmpireNullableIntProperty();
 ///
-///if (age.isNull)
-///{
+/// if (age.isNull)
+/// {
 ///   print("I'm Null");
-///}
-///```
+/// }
+/// ```
 ///
-///Other Usages Examples
-///```dart
+/// Other Usages Examples
+/// ```dart
 ///
-///final age = EmpireNullableIntProperty();
+/// final age = EmpireNullableIntProperty();
 ///
-///print('${age + 5}'); //throws EmpireNullValueException because no value has been set yet.
+/// print('${age + 5}'); //throws EmpireNullValueException because no value has been set yet.
 ///
-///age(10)
+/// age(10)
 ///
-///print('${age - 5}'); //prints 5
+/// print('${age - 5}'); //prints 5
 ///
-///```
+/// ```
 ///
 class EmpireNullableIntProperty extends EmpireProperty<int?> {
   EmpireNullableIntProperty({int? value, super.propertyName}) : super(value);
 
-  ///Factory constructor for initializing an [EmpireNullableIntProperty] to zero.
+  /// Factory constructor for initializing an [EmpireNullableIntProperty] to zero.
   ///
-  ///See [EmpireProperty] for [propertyName] usages.
+  /// See [EmpireProperty] for [propertyName] usages.
   ///
-  ///## Example
+  /// ## Example
   ///
-  ///```dart
-  ///final numberOfFriends = EmpireNullableIntProperty.zero();
-  ///```
+  /// ```dart
+  /// final numberOfFriends = EmpireNullableIntProperty.zero();
+  /// ```
   factory EmpireNullableIntProperty.zero({String? propertyName}) {
     return EmpireNullableIntProperty(value: 0, propertyName: propertyName);
   }
@@ -209,7 +209,7 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
 
   /// Adds [other] to this number.
   ///
-  ///This does not set the value for this [EmpireNullableIntProperty].
+  /// This does not set the value for this [EmpireNullableIntProperty].
   ///
   /// If the underlying value is [null] throws an [EmpirePropertyNullValueException].
   ///
@@ -225,7 +225,7 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
 
   /// Subtracts [other] from this number.
   ///
-  ///This does not set the value for this [EmpireNullableIntProperty].
+  /// This does not set the value for this [EmpireNullableIntProperty].
   ///
   /// If the underlying value is [null] throws an [EmpirePropertyNullValueException].
   ///
@@ -241,7 +241,7 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
 
   /// Divides this number by [other].
   ///
-  ///This does not set the value for this [EmpireNullableIntProperty].
+  /// This does not set the value for this [EmpireNullableIntProperty].
   double divide<E extends num>(E other) {
     return isNotNull
         ? _value! / other
@@ -251,7 +251,7 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
 
   /// Euclidean modulo of this number by [other].
   ///
-  ///This does not set the value for this [EmpireNullableIntProperty].
+  /// This does not set the value for this [EmpireNullableIntProperty].
   ///
   /// Returns the remainder of the Euclidean division.
   /// The Euclidean division of two integers `a` and `b`
@@ -285,7 +285,7 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
 
   /// Multiplies this number by [other].
   ///
-  ///This does not set the value for this [EmpireNullableIntProperty].
+  /// This does not set the value for this [EmpireNullableIntProperty].
   ///
   /// The result is an [int], as described by [int.*],
   /// if both this number and [other] are integers,

--- a/lib/src/empire_int_property.dart
+++ b/lib/src/empire_int_property.dart
@@ -242,6 +242,8 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
   /// Divides this number by [other].
   ///
   /// This does not set the value for this [EmpireNullableIntProperty].
+  ///
+  /// If the underlying value is [null] throws an [EmpirePropertyNullValueException].
   double divide<E extends num>(E other) {
     return isNotNull
         ? _value! / other

--- a/lib/src/empire_int_property.dart
+++ b/lib/src/empire_int_property.dart
@@ -211,6 +211,8 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
   ///
   ///This does not set the value for this [EmpireNullableIntProperty].
   ///
+  /// If the underlying value is [null] throws an [EmpirePropertyNullValueException].
+  ///
   /// The result is an [int], as described by [int.+],
   /// if both this number and [other] is an integer,
   /// otherwise the result is a [double].
@@ -224,6 +226,8 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
   /// Subtracts [other] from this number.
   ///
   ///This does not set the value for this [EmpireNullableIntProperty].
+  ///
+  /// If the underlying value is [null] throws an [EmpirePropertyNullValueException].
   ///
   /// The result is an [int], as described by [int.-],
   /// if both this number and [other] is an integer,
@@ -265,6 +269,8 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
   /// if both this number and [other] are integers,
   /// otherwise the result is a [double].
   ///
+  /// If the underlying value is [null] throws an [EmpirePropertyNullValueException].
+  ///
   /// Example:
   /// ```dart
   /// final number = EmpireNullableIntProperty(5);
@@ -284,6 +290,8 @@ class EmpireNullableIntProperty extends EmpireProperty<int?> {
   /// The result is an [int], as described by [int.*],
   /// if both this number and [other] are integers,
   /// otherwise the result is a [double].
+  ///
+  /// If the underlying value is [null] throws an [EmpirePropertyNullValueException].
   E multiply<E extends num>(E other) {
     return isNotNull
         ? (_value! * other) as E

--- a/test/empire_property_tests/double_property_test.dart
+++ b/test/empire_property_tests/double_property_test.dart
@@ -87,7 +87,7 @@ void main() {
 
       expect(find.text(viewModel.percentage.toString()), findsOneWidget);
 
-      final result = viewModel.percentage + addend;
+      final result = viewModel.percentage.add(addend);
 
       viewModel.percentage(result);
       await tester.pumpAndSettle();
@@ -107,7 +107,7 @@ void main() {
 
       expect(find.text(viewModel.percentage.toString()), findsOneWidget);
 
-      final result = viewModel.percentage - subtrahend;
+      final result = viewModel.percentage.subtract(subtrahend);
 
       viewModel.percentage(result);
 
@@ -128,7 +128,7 @@ void main() {
 
       expect(find.text(viewModel.percentage.toString()), findsOneWidget);
 
-      final result = viewModel.percentage * multiplier;
+      final result = viewModel.percentage.multiply(multiplier);
 
       viewModel.percentage(result);
 
@@ -149,7 +149,7 @@ void main() {
 
       expect(find.text(viewModel.percentage.toString()), findsOneWidget);
 
-      final result = viewModel.percentage / divisor;
+      final result = viewModel.percentage.divide(divisor);
 
       viewModel.percentage(result);
 
@@ -191,6 +191,78 @@ void main() {
       viewModel.percentage(3);
       final result = viewModel.percentage.isNegative;
       expect(result, isFalse);
+    });
+
+    test('add - other is int - returns correct double value', () {
+      const expected = 2;
+      final number = EmpireDoubleProperty(1);
+      final result = number.add(1);
+
+      expect(result, equals(expected));
+    });
+
+    test('add - other is double - returns correct double value', () {
+      const expected = 2.5;
+      final number = EmpireDoubleProperty(1);
+      final result = number.add(1.5);
+
+      expect(result, equals(expected));
+    });
+
+    test('subtract - other is int - returns correct double value', () {
+      const expected = 2;
+      final number = EmpireDoubleProperty(3);
+      final result = number.subtract(1);
+
+      expect(result, equals(expected));
+    });
+
+    test('subtract - other is double - returns correct double value', () {
+      const expected = 2.5;
+      final number = EmpireDoubleProperty(4);
+      final result = number.subtract(1.5);
+
+      expect(result, equals(expected));
+    });
+
+    test('multiply - other is int - returns correct double value', () {
+      const expected = 4;
+      final number = EmpireDoubleProperty(2);
+      final result = number.multiply(2);
+
+      expect(result, equals(expected));
+    });
+
+    test('multiply - other is double - returns correct double value', () {
+      const expected = 5.4;
+      final number = EmpireDoubleProperty(2);
+      final result = number.multiply(2.7);
+
+      expect(result, equals(expected));
+    });
+
+    test('divide - returns correct double value', () {
+      const expected = 4.0;
+      final number = EmpireDoubleProperty(8);
+      final result = number.divide(2);
+
+      expect(result, equals(expected));
+    });
+
+    test('mod - other is int - returns correct double value', () {
+      const expected = 2;
+      final number = EmpireDoubleProperty(5);
+      final result = number.mod(3);
+
+      expect(result, equals(expected));
+    });
+
+    test('mod - other is double - returns correct double value', () {
+      const expected = 1.5;
+      final number = EmpireDoubleProperty(5);
+      final result = number.mod(3.5);
+
+      expect(result, equals(expected));
     });
   });
 }

--- a/test/empire_property_tests/int_property_test.dart
+++ b/test/empire_property_tests/int_property_test.dart
@@ -86,7 +86,7 @@ void main() {
 
       expect(find.text(viewModel.age.toString()), findsOneWidget);
 
-      final result = viewModel.age + addend;
+      final result = viewModel.age.add(addend);
 
       viewModel.age(result);
       await tester.pumpAndSettle();
@@ -106,7 +106,7 @@ void main() {
 
       expect(find.text(viewModel.age.toString()), findsOneWidget);
 
-      final result = viewModel.age - subtrahend;
+      final result = viewModel.age.subtract(subtrahend);
 
       viewModel.age(result);
 
@@ -127,7 +127,7 @@ void main() {
 
       expect(find.text(viewModel.age.toString()), findsOneWidget);
 
-      final result = viewModel.age * multiplier;
+      final result = viewModel.age.multiply(multiplier);
 
       viewModel.age(result);
 
@@ -140,7 +140,7 @@ void main() {
     testWidgets('division - widget updates', (tester) async {
       const int expectedValue = 2;
       const int startingValue = 10;
-      const int multiplier = 5;
+      const int divisor = 5;
 
       viewModel.age(startingValue);
 
@@ -148,9 +148,9 @@ void main() {
 
       expect(find.text(viewModel.age.toString()), findsOneWidget);
 
-      final result = viewModel.age / multiplier;
+      final result = viewModel.age.divide(divisor);
 
-      viewModel.age(result);
+      viewModel.age(result.toInt());
 
       await tester.pumpAndSettle();
 

--- a/test/empire_property_tests/int_property_test.dart
+++ b/test/empire_property_tests/int_property_test.dart
@@ -209,5 +209,77 @@ void main() {
       expect(result, equals(expected));
       expect(viewModel.age.value, equals(expected));
     });
+
+    test('add - other is int - returns correct int value', () {
+      const expected = 2;
+      final number = EmpireIntProperty(1);
+      final result = number.add(1);
+
+      expect(result, equals(expected));
+    });
+
+    test('add - other is double - returns correct double value', () {
+      const expected = 2.5;
+      final number = EmpireIntProperty(1);
+      final result = number.add(1.5);
+
+      expect(result, equals(expected));
+    });
+
+    test('subtract - other is int - returns correct int value', () {
+      const expected = 2;
+      final number = EmpireIntProperty(3);
+      final result = number.subtract(1);
+
+      expect(result, equals(expected));
+    });
+
+    test('subtract - other is double - returns correct double value', () {
+      const expected = 2.5;
+      final number = EmpireIntProperty(4);
+      final result = number.subtract(1.5);
+
+      expect(result, equals(expected));
+    });
+
+    test('multiply - other is int - returns correct int value', () {
+      const expected = 4;
+      final number = EmpireIntProperty(2);
+      final result = number.multiply(2);
+
+      expect(result, equals(expected));
+    });
+
+    test('multiply - other is double - returns correct double value', () {
+      const expected = 5.4;
+      final number = EmpireIntProperty(2);
+      final result = number.multiply(2.7);
+
+      expect(result, equals(expected));
+    });
+
+    test('divide - returns correct double value', () {
+      const expected = 4.0;
+      final number = EmpireIntProperty(8);
+      final result = number.divide(2);
+
+      expect(result, equals(expected));
+    });
+
+    test('mod - other is int - returns correct int value', () {
+      const expected = 2;
+      final number = EmpireIntProperty(5);
+      final result = number.mod(3);
+
+      expect(result, equals(expected));
+    });
+
+    test('mod - other is double - returns correct double value', () {
+      const expected = 1.5;
+      final number = EmpireIntProperty(5);
+      final result = number.mod(3.5);
+
+      expect(result, equals(expected));
+    });
   });
 }


### PR DESCRIPTION
resolves #83 

**Breaking Change**

- Implemented arithmetic functions for EmpireIntProperty and EmprieDoubleProperty, and their nullable variants
- Removed the operator overrides
- Updated, cleaned up, and fixed documentation