### PR TITLE
Fix setBusyStatus on EmpireViewModel

### DIFF
--- a/lib/src/empire_view_model.dart
+++ b/lib/src/empire_view_model.dart
@@ -131,13 +131,13 @@ abstract class EmpireViewModel {
   ///
   ///Updating the busy status is automatic when using the [doAsync] function.
   void setBusyStatus({required bool isBusy, dynamic busyTaskKey}) {
-    if (_busy != isBusy) {
+    if (_busy != isBusy || busyTaskKey != null) {
       if (isBusy) {
         _addBusyTaskKey(busyTaskKey);
       } else {
         _removeBusyTaskKey(busyTaskKey);
       }
-      _busy = isBusy;
+      _busy = _busyTaskKeys.isNotEmpty || isBusy;
       notifyChanges([EmpireStateChanged(isBusy, !isBusy)]);
     }
   }

--- a/test/empire_view_model_test.dart
+++ b/test/empire_view_model_test.dart
@@ -35,4 +35,57 @@ void main() {
     expect(viewModel.name.value, equals(originalName));
     expect(viewModel.age.value, equals(originalAge));
   });
+
+  test('setBusyStatus', () {
+    const taskKeyOne = 'taskOne';
+    const taskKeyTwo = 'taskTwo';
+    const taskKeyThree = 'taskThree';
+
+    //Set all tasks to busy
+    viewModel.setBusyStatus(isBusy: true, busyTaskKey: taskKeyOne);
+
+    expect(viewModel.busy, isTrue);
+
+    bool isTaskKeyOneBusy = viewModel.isTaskInProgress(taskKeyOne);
+
+    expect(isTaskKeyOneBusy, isTrue);
+
+    viewModel.setBusyStatus(isBusy: true, busyTaskKey: taskKeyTwo);
+
+    expect(viewModel.busy, isTrue);
+
+    bool isTaskKeyTwoBusy = viewModel.isTaskInProgress(taskKeyTwo);
+
+    expect(isTaskKeyTwoBusy, isTrue);
+
+    viewModel.setBusyStatus(isBusy: true, busyTaskKey: taskKeyThree);
+
+    expect(viewModel.busy, isTrue);
+
+    bool isTaskKeyThreeBusy = viewModel.isTaskInProgress(taskKeyThree);
+
+    expect(isTaskKeyThreeBusy, isTrue);
+
+    //Incrementally remove busy status
+    viewModel.setBusyStatus(isBusy: false, busyTaskKey: taskKeyOne);
+
+    isTaskKeyOneBusy = viewModel.isTaskInProgress(taskKeyOne);
+
+    expect(isTaskKeyOneBusy, isFalse);
+    expect(viewModel.busy, isTrue);
+
+    viewModel.setBusyStatus(isBusy: false, busyTaskKey: taskKeyTwo);
+
+    isTaskKeyTwoBusy = viewModel.isTaskInProgress(taskKeyTwo);
+
+    expect(isTaskKeyTwoBusy, isFalse);
+    expect(viewModel.busy, isTrue);
+
+    viewModel.setBusyStatus(isBusy: false, busyTaskKey: taskKeyThree);
+
+    isTaskKeyThreeBusy = viewModel.isTaskInProgress(taskKeyThree);
+
+    expect(isTaskKeyThreeBusy, isFalse);
+    expect(viewModel.busy, isFalse);
+  });
 }


### PR DESCRIPTION
 - Fixed the logic to determine whether a ViewModel is busy when there are multiple different busyTaskKeys assigned
 - Added unit test for setBusyStatus