### PR TITLE
Add setAsOriginal argument on EmpireProperties

### DIFF
--- a/lib/src/empire_property.dart
+++ b/lib/src/empire_property.dart
@@ -77,12 +77,22 @@ class EmpireProperty<T> implements EmpireValue<T> {
     _originalValue = _value;
   }
 
+  ///Links this EmpireProperty instance with an [EmpireViewModel].
+  ///
   void setViewModel(EmpireViewModel viewModel) {
     _viewModel = viewModel;
   }
 
-  void call(T value, {bool notifyChange = true}) {
-    set(value, notifyChange: notifyChange);
+  /// Updates the underlying [value] for this EmpireProperty.
+  ///
+  /// If [notifyChange] is true, a UI update will be triggered after the change occurs. Otherwise,
+  /// only the value will be set.
+  ///
+  /// If [setAsOriginal] is true, updating the value will also set the [originalValue] to the
+  /// current value. See also [setOriginalValueToCurrent] and [reset]
+  ///
+  void call(T value, {bool notifyChange = true, bool setAsOriginal = false}) {
+    set(value, notifyChange: notifyChange, setAsOriginal: setAsOriginal);
   }
 
   ///Updates the original value to what the current value of this property is.
@@ -114,7 +124,7 @@ class EmpireProperty<T> implements EmpireValue<T> {
   ///Updates the property value. Notifies any listeners to the change
   ///
   ///Returns the updated value
-  T set(T value, {bool notifyChange = true}) {
+  T set(T value, {bool notifyChange = true, bool setAsOriginal = false}) {
     final previousValue = _value;
     _value = value;
     if (notifyChange && previousValue != value) {
@@ -122,10 +132,15 @@ class EmpireProperty<T> implements EmpireValue<T> {
         EmpireStateChanged(value, previousValue, propertyName: propertyName)
       ]);
     }
+
+    if (setAsOriginal) {
+      _originalValue = _value;
+    }
+
     return _value;
   }
 
-  ///Resets the value to what it was initialized with.
+  ///Resets the [value] to the [originalValue].
   ///
   ///If [T] is a  class with properties, changing the properties directly on the object
   ///instead of updating this EmpireProperty with a new instance of [T] with the updated values will
@@ -135,7 +150,7 @@ class EmpireProperty<T> implements EmpireValue<T> {
   ///## Usage
   ///
   ///```dart
-  ///late final EmpireProperty<int> age = createProperty(10); //age.value is 10
+  ///final age = EmpireProperty<int>(10); //age.value is 10
   ///
   ///age(20); //age.value is 20
   ///age(25); //age.value is 25
@@ -167,12 +182,12 @@ class EmpireProperty<T> implements EmpireValue<T> {
   ///### Usage
   ///
   ///```dart
-  ///final EmpireProperty<int> age = createProperty(10);
+  ///final age = EmpireProperty<int>(10);
   ///
   ///age.equals(10); //returns true
   ///
   ///
-  ///final EmpireProperty<int> ageTwo = createProperty(10);
+  ///final ageTwo = EmpireProperty<int>(10);
   ///
   ///age.equals(ageTwo); //returns true
   ///```

--- a/test/empire_property_tests/empire_property_test.dart
+++ b/test/empire_property_tests/empire_property_test.dart
@@ -209,6 +209,28 @@ void main() {
 
       expect(name.value, equals(expectedValue));
     });
+    test(
+        'setAsOriginal - argument is false - original not set to current value',
+        () {
+      const String expected = 'Bob';
+      final name = EmpireProperty<String?>(expected);
+      name.setViewModel(viewModel);
+
+      name('Steve', setAsOriginal: false);
+
+      expect(name.originalValue, equals(expected));
+    });
+
+    test('setAsOriginal - argument is true - original is set to current value',
+        () {
+      const String expected = 'Steve';
+      final name = EmpireProperty<String?>('Bob');
+      name.setViewModel(viewModel);
+
+      name(expected, setAsOriginal: true);
+
+      expect(name.originalValue, equals(expected));
+    });
   });
   group('Property Reset Tests', () {
     testWidgets('reset - notifyChange is true - UI Updates', (tester) async {


### PR DESCRIPTION
resolves #81 

- added new optional argument to the `call` and `set` functions on EmpireProperties call `setAsOriginal`. If true, when the value is updated, it will update the original value to the new current value. 
- Added some missing documentation