### PR TITLE
Guard against reusing EmpireViewModels instances across multiple EmpireWidgets

### DIFF
--- a/lib/src/empire_exceptions.dart
+++ b/lib/src/empire_exceptions.dart
@@ -1,10 +1,15 @@
 ///Base class for any Empire specific exception
 abstract class EmpireException implements Exception {
   final StackTrace? stack;
-  final String? propertyName;
   final Type type;
 
-  EmpireException(this.stack, this.propertyName, this.type);
+  EmpireException(this.stack, this.type);
+}
+
+abstract class EmpirePropertyException extends EmpireException {
+  final String? propertyName;
+
+  EmpirePropertyException(super.stack, this.propertyName, super.type);
 }
 
 ///Thrown when an not-null-safe action is performed on a Nullable Empire Property, and the underlying value
@@ -12,7 +17,7 @@ abstract class EmpireException implements Exception {
 ///
 ///An example is performing an arithmetic operation on an [EmpireNullableIntProperty] when the int value
 ///was null
-class EmpirePropertyNullValueException extends EmpireException {
+class EmpirePropertyNullValueException extends EmpirePropertyException {
   EmpirePropertyNullValueException(super.stack, super.propertyName, super.type);
 
   @override
@@ -23,11 +28,20 @@ class EmpirePropertyNullValueException extends EmpireException {
 ///Thrown when an EmpireProperty value is changed and attempts to update the UI, but has not been added to the
 ///empireProps property of the associated EmpireViewModel
 ///
-class PropertyNotAssignedToEmpireViewModelException extends EmpireException {
+class PropertyNotAssignedToEmpireViewModelException
+    extends EmpirePropertyException {
   PropertyNotAssignedToEmpireViewModelException(
       super.stack, super.propertyName, super.type);
 
   @override
   String toString() =>
       'PropertyNotAssignedToEmpireViewModelException: The value for ${propertyName ?? type} changed and failed to update the UI. Did you forget to add it to empireProps?.\nStack: $stack';
+}
+
+class EmpireViewModelAlreadyAssignedException extends EmpireException {
+  EmpireViewModelAlreadyAssignedException(super.stack, super.type);
+
+  @override
+  String toString() =>
+      'EmpireViewModelAlreadyAssignedException: The View Model of type $type has already been assigned to a different EmpireWidget.\nStack: $stack';
 }

--- a/lib/src/empire_property.dart
+++ b/lib/src/empire_property.dart
@@ -207,6 +207,7 @@ class EmpireProperty<T> implements EmpireValue<T> {
   }
 
   @override
+  // ignore: non_nullable_equals_parameter
   bool operator ==(dynamic other) => equals(other);
 
   @override

--- a/lib/src/empire_view_model.dart
+++ b/lib/src/empire_view_model.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:empire/src/empire_exceptions.dart';
 import 'package:flutter/foundation.dart';
 
 import 'empire_property.dart';
@@ -27,6 +28,16 @@ abstract class EmpireViewModel {
   final List<dynamic> _busyTaskKeys = [];
   List<dynamic> get activeTasks => _busyTaskKeys;
 
+  int? _assignedTo;
+
+  /// The [EmpireWidget] that the view model is currently assigned to
+  int? get assignedTo => _assignedTo;
+
+  /// Whether the view model has already been assigned to a widget
+  ///
+  /// This is used to prevent the view model from being assigned to multiple widgets
+  bool get assignedToWidget => _assignedTo != null;
+
   EmpireViewModel() {
     for (var element in empireProps) {
       element.setViewModel(this);
@@ -37,6 +48,21 @@ abstract class EmpireViewModel {
   ///
   ///Properties on the implementation must be added to this list in order to be reactive and update the UI on change.
   Iterable<EmpireProperty> get empireProps;
+
+  ///Creates associates the view model with a specific [EmpireWidget] via the widgets hash code.
+  ///
+  ///This method is called automatically by the [EmpireState] when the view model is assigned to a widget.
+  ///
+  ///**This method should not be called manually.**
+  void assignTo(int widgetHash) {
+    if (_assignedTo != null) {
+      throw EmpireViewModelAlreadyAssignedException(
+        StackTrace.current,
+        runtimeType,
+      );
+    }
+    _assignedTo = widgetHash;
+  }
 
   ///Adds an event handler which gets executed each time an [EmpireProperty] value is changed.
   ///

--- a/lib/src/empire_view_model.dart
+++ b/lib/src/empire_view_model.dart
@@ -55,7 +55,7 @@ abstract class EmpireViewModel {
   ///
   ///**This method should not be called manually.**
   void assignTo(int widgetHash) {
-    if (_assignedTo != null) {
+    if (assignedToWidget) {
       throw EmpireViewModelAlreadyAssignedException(
         StackTrace.current,
         runtimeType,

--- a/lib/src/empire_widget.dart
+++ b/lib/src/empire_widget.dart
@@ -95,6 +95,10 @@ abstract class EmpireState<T extends EmpireWidget, E extends EmpireViewModel>
   bool get isBusy => viewModel.busy;
 
   EmpireState(this.viewModel) {
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => viewModel.assignTo(widget.hashCode),
+    );
+
     viewModel.addOnStateChangedListener((events) {
       if (widget.debugPrintStateChanges && kDebugMode) {
         // ignore: avoid_print


### PR DESCRIPTION
closes #95 

Add a function to the post frame callback cycle when initializing an EmpireWidget to link the widget to it's view model by it's hash code. 

This new function checks to see if the view model has already been associated with another widget. If so, it will throw an `EmpireViewModelAlreadyAssignedException`. 

This change will prevent unintended state behaviour.

This is a breaking change for anyone who was trying to share view models across instances.