### PR TITLE
Fix a bug when resetting lists or maps (#1)

### DIFF
--- a/lib/src/empire_bool_property.dart
+++ b/lib/src/empire_bool_property.dart
@@ -8,7 +8,8 @@ part of 'empire_property.dart';
 ///When the value of this changes, it will send a [EmpireStateChanged] event by default. This includes
 ///automatically triggering a UI rebuild.
 class EmpireBoolProperty extends EmpireProperty<bool> {
-  EmpireBoolProperty(super.value, {super.propertyName});
+  EmpireBoolProperty(super.value, {super.propertyName})
+      : super(isPrimitiveType: true);
 
   ///Whether the underlying value is true
   bool get isTrue => _value;
@@ -33,7 +34,8 @@ class EmpireBoolProperty extends EmpireProperty<bool> {
 ///When the value of this changes, it will send a [EmpireStateChanged] event by default. This includes
 ///automatically triggering a UI rebuild.
 class EmpireNullableBoolProperty extends EmpireProperty<bool?> {
-  EmpireNullableBoolProperty({bool? value, super.propertyName}) : super(value);
+  EmpireNullableBoolProperty({bool? value, super.propertyName})
+      : super(value, isPrimitiveType: true);
 
   ///Whether the underlying value is not null and true
   bool get isTrue => isNotNull && _value == true;

--- a/lib/src/empire_cloneable.dart
+++ b/lib/src/empire_cloneable.dart
@@ -1,0 +1,3 @@
+abstract class EmpireCloneable<T> {
+  T clone();
+}

--- a/lib/src/empire_date_time_property.dart
+++ b/lib/src/empire_date_time_property.dart
@@ -8,7 +8,8 @@ part of 'empire_property.dart';
 ///When the value of this changes, it will send a [EmpireStateChanged] event by default. This includes
 ///automatically triggering a UI rebuild.
 class EmpireDateTimeProperty extends EmpireProperty<DateTime> {
-  EmpireDateTimeProperty(super.value, {super.propertyName});
+  EmpireDateTimeProperty(super.value, {super.propertyName})
+      : super(isPrimitiveType: true);
 
   ///Factory constructor for initializing an [EmpireDateTimeProperty] to the current Date/Time.
   ///
@@ -363,7 +364,7 @@ class EmpireDateTimeProperty extends EmpireProperty<DateTime> {
 ///automatically triggering a UI rebuild.
 class EmpireNullableDateTimeProperty extends EmpireProperty<DateTime?> {
   EmpireNullableDateTimeProperty({DateTime? value, super.propertyName})
-      : super(value);
+      : super(value, isPrimitiveType: true);
 
   ///Factory constructor for initializing an [EmpireNullableDateTimeProperty] to the current Date/Time.
   ///

--- a/lib/src/empire_double_property.dart
+++ b/lib/src/empire_double_property.dart
@@ -17,7 +17,8 @@ part of 'empire_property.dart';
 /// print('${percentage.add(5.2)}'); //prints 15.2
 /// ```
 class EmpireDoubleProperty extends EmpireProperty<double> {
-  EmpireDoubleProperty(super.value, {super.propertyName});
+  EmpireDoubleProperty(super.value, {super.propertyName})
+      : super(isPrimitiveType: true);
 
   /// Factory constructor for initializing an [EmpireDoubleProperty] to zero.
   ///
@@ -182,7 +183,7 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
 ///
 class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
   EmpireNullableDoubleProperty({double? value, super.propertyName})
-      : super(value);
+      : super(value, isPrimitiveType: true);
 
   factory EmpireNullableDoubleProperty.zero({String? propertyName}) {
     return EmpireNullableDoubleProperty(value: 0, propertyName: propertyName);

--- a/lib/src/empire_int_property.dart
+++ b/lib/src/empire_int_property.dart
@@ -17,7 +17,8 @@ part of 'empire_property.dart';
 /// print('${age.add(5)}'); //prints 15
 /// ```
 class EmpireIntProperty extends EmpireProperty<int> {
-  EmpireIntProperty(super.value, {super.propertyName});
+  EmpireIntProperty(super.value, {super.propertyName})
+      : super(isPrimitiveType: true);
 
   /// Factory constructor for initializing an [EmpireIntProperty] to zero.
   ///
@@ -161,7 +162,8 @@ class EmpireIntProperty extends EmpireProperty<int> {
 /// ```
 ///
 class EmpireNullableIntProperty extends EmpireProperty<int?> {
-  EmpireNullableIntProperty({int? value, super.propertyName}) : super(value);
+  EmpireNullableIntProperty({int? value, super.propertyName})
+      : super(value, isPrimitiveType: true);
 
   /// Factory constructor for initializing an [EmpireNullableIntProperty] to zero.
   ///

--- a/lib/src/empire_list_property.dart
+++ b/lib/src/empire_list_property.dart
@@ -464,4 +464,20 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   /// formatted String
   @override
   String toString() => 'EmpireListProperty([${_value.join(", ")}])';
+
+  @override
+  void reset({bool notifyChange = true}) {
+    final currentValue = _value;
+    _value = List<T>.from(_originalValue);
+
+    if (notifyChange) {
+      viewModel.notifyChanges([
+        EmpireStateChanged(
+          _originalValue,
+          currentValue,
+          propertyName: propertyName,
+        )
+      ]);
+    }
+  }
 }

--- a/lib/src/empire_map_property.dart
+++ b/lib/src/empire_map_property.dart
@@ -329,4 +329,20 @@ class EmpireMapProperty<K, V> extends EmpireProperty<Map<K, V>> {
   V? operator [](K key) {
     return _value[key];
   }
+
+  @override
+  void reset({bool notifyChange = true}) {
+    final currentValue = _value;
+    _value = Map<K, V>.from(_originalValue);
+
+    if (notifyChange) {
+      viewModel.notifyChanges([
+        EmpireStateChanged(
+          _originalValue,
+          currentValue,
+          propertyName: propertyName,
+        )
+      ]);
+    }
+  }
 }

--- a/lib/src/empire_string_property.dart
+++ b/lib/src/empire_string_property.dart
@@ -5,7 +5,8 @@ part of 'empire_property.dart';
 ///When the value of this changes, it will send a [EmpireStateChanged] event by default. This includes
 ///automatically triggering a UI rebuild.
 class EmpireStringProperty extends EmpireProperty<String> {
-  EmpireStringProperty(super.value, {super.propertyName});
+  EmpireStringProperty(super.value, {super.propertyName})
+      : super(isPrimitiveType: true);
 
   ///Factory constructor for initializing an [EmpireStringProperty] to an empty [String].
   ///
@@ -72,7 +73,7 @@ class EmpireStringProperty extends EmpireProperty<String> {
 ///automatically triggering a UI rebuild.
 class EmpireNullableStringProperty extends EmpireProperty<String?> {
   EmpireNullableStringProperty({String? value, super.propertyName})
-      : super(value);
+      : super(value, isPrimitiveType: true);
 
   ///Whether the string value is empty
   ///

--- a/test/empire_property_tests/date_time_property_test.dart
+++ b/test/empire_property_tests/date_time_property_test.dart
@@ -162,5 +162,17 @@ void main() {
       final property = EmpireNullableDateTimeProperty(value: expected);
       expect(property.value, equals(expected));
     });
+
+    test('resetting retains original value', () {
+      final property = EmpireNullableDateTimeProperty();
+
+      property.set(DateTime.now(), notifyChange: false);
+
+      property.reset(notifyChange: false);
+
+      property.set(DateTime.now(), notifyChange: false);
+
+      expect(property.originalValue, equals(null));
+    });
   });
 }

--- a/test/empire_property_tests/list_property_test.dart
+++ b/test/empire_property_tests/list_property_test.dart
@@ -402,5 +402,21 @@ void main() {
       const expected = 'EmpireListProperty([1, 2, 3])';
       expect(numbers.toString(), expected);
     });
+
+    test('resetting retains original value', () {
+      final numbers = EmpireListProperty<int>.empty();
+      final items = [1, 2, 3];
+
+      numbers.addAll(items, notifyChanges: false);
+
+      expect(numbers.originalValue.isEmpty, isTrue);
+
+      numbers.reset(notifyChange: false);
+
+      expect(numbers.originalValue.isEmpty, isTrue);
+
+      numbers.addAll(items, notifyChanges: false);
+      expect(numbers.originalValue.isEmpty, isTrue);
+    });
   });
 }

--- a/test/empire_property_tests/map_property_test.dart
+++ b/test/empire_property_tests/map_property_test.dart
@@ -412,5 +412,19 @@ void main() {
       expect(data.containsKey(key), isTrue);
       expect(data.containsValue(value), isTrue);
     });
+
+    test('resetting retains original value', () {
+      final data = EmpireMapProperty<String, String>.empty();
+      data.setViewModel(viewModel);
+      data.add('name', 'Bob');
+
+      data.reset();
+
+      expect(data.isEmpty, isTrue);
+
+      data.add('name', 'Bob');
+
+      expect(data.originalValue.isEmpty, isTrue);
+    });
   });
 }

--- a/test/empire_property_tests/string_property_test.dart
+++ b/test/empire_property_tests/string_property_test.dart
@@ -154,6 +154,17 @@ void main() {
 
       expect(result, equals(expectedValue));
     });
+
+    test('resetting retains original value', () {
+      const String expectedValue = 'John';
+      viewModel.name(expectedValue);
+
+      viewModel.name.reset();
+
+      viewModel.name(expectedValue);
+
+      expect(viewModel.name.originalValue, equals('Bob'));
+    });
   });
 
   group('NullableStringProperty Tests', () {


### PR DESCRIPTION
This pull request warns the user about the issue described in #98 and fixes the issue when using EmpireListProperty or EmpireMapProperty.

We didn't want to introduce a breaking change, so we opted for the following:

1. Added a field called "isPrimitiveType" to EmpireProperty which defaults to false.
2. Added a new interface called EmpireCloneable which provides a clone() method, intended to allow the user to provide their own means of deeply copying the empire property value.
3. In the default implementation of reset, if the value implements EmpireCloneable, call the clone() to copy the original value rather than copying by reference.
4. In the default implementation of reset, if the value isPrimitiveType is false, maintain the original method of resetting (which still works fine for any immutable value like an int, but show a warning to the user about the bug.
5. In the default implementation of reset, if the value isPrimitiveType is true, simply copy the value and don't show the warning
6. Update the implementations of the immutable EmpireProperty derivatives (EmpireIntPropert, etc) to set isPrimitiveType to true so the warning is suppressed.
7. Override the implementation of reset in EmpireListProperty and EmpireMapProperty so that new lists/maps are created instead of copying by reference.
8. Updated the documentation for reset to describe the behavior when T is mutable.

As a result of this change, anyone using the EmpireProperty derivatives should see the bug go away, and should not see the warning.  Anyone using EmpireProperty<T> will see the warning and have enough info in the method documentation to avoid it or suppress the warning.

We've also added tests for some of the EmpireProperty derivatives to confirm the behavior, then fix it.

