### PR TITLE
Proposed link to rebranded/maintained library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+Please note that this library is no longer actively maintained. For an updated fork of this library, please see <a href="https://github.com/thirdversion/flutter_current"><b>Flutter Current</b></a>.
+
+---
+
 <p align="center">
     <img src="https://github.com/strivesolutions/flutter_empire/raw/main/images/EmpireLogoMD.png"/>
 </p>


### PR DESCRIPTION
As Flutter Empire is no longer actively maintained, we hope that you will consider adding this link to the README in order to link to our forked library, Flutter Current.

We will be keeping Flutter Current up to date and adding new functionality over time.